### PR TITLE
Avoid updatedAt error

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -15,7 +15,7 @@
 
 SET NAMES utf8mb4;
 SET FOREIGN_KEY_CHECKS = 0;
-SET sql_mode = '';
+SET sql_mode = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER';
 
 -- ----------------------------
 -- Table structure for staart-access-tokens

--- a/schema.sql
+++ b/schema.sql
@@ -15,6 +15,7 @@
 
 SET NAMES utf8mb4;
 SET FOREIGN_KEY_CHECKS = 0;
+SET sql_mode = '';
 
 -- ----------------------------
 -- Table structure for staart-access-tokens


### PR DESCRIPTION
When running `schema.sql` on a new MySQL database (latest official docker image). You receive the following error for tables that are calling timestamp functions:

```
ERROR 1067 (42000): Invalid default value for 'updatedAt'
```

By setting SQL mode to be blank, you avoid the error.

You can make this more fine-grained and keep the other permissions if you like:

By just removing:

```
NO_ZERO_IN_DATE,NO_ZERO_DATE
```
and doing this instead:
```
SET sql_mode = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
```

Happy to update my PR with that instead.