### PR TITLE
Add AWS_ELASTIC_REGION and ignore .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,7 @@ STRIPE_PRODUCT_ID = "stripe-product-id"
 AWS_ELASTIC_ACCESS_KEY = "aws-access-key-xxxxxxxxxx"
 AWS_ELASTIC_SECRET_KEY = "aws-secret-key-xxxxxxxxxx"
 AWS_ELASTIC_HOST = "https://name.region.es.amazonaws.com"
+AWS_ELASTIC_REGION = "eu-west-2"
 
 ##################################
 # Optional environment variables #

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,7 @@ typings/
 dist/
 docs/
 src/app.ts
+
+# Ignore .env
+*.env
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "staart-manager",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "main": "index.js",
   "repository": "git@github.com:AnandChowdhary/staart.git",
   "author": "Anand Chowdhary <mail@anandchowdhary.com>",
@@ -146,5 +146,5 @@
     "setup"
   ],
   "snyk": true,
-  "staart-version": "1.1.8"
+  "staart-version": "1.1.9"
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -103,3 +103,4 @@ export const STRIPE_PRODUCT_ID = process.env.STRIPE_PRODUCT_ID || "";
 export const AWS_ELASTIC_ACCESS_KEY = process.env.AWS_ELASTIC_ACCESS_KEY || "";
 export const AWS_ELASTIC_SECRET_KEY = process.env.AWS_ELASTIC_SECRET_KEY || "";
 export const AWS_ELASTIC_HOST = process.env.AWS_ELASTIC_HOST || "";
+export const AWS_ELASTIC_REGION = process.env.AWS_ELASTIC_REGION || "";

--- a/src/helpers/elasticsearch.ts
+++ b/src/helpers/elasticsearch.ts
@@ -4,6 +4,7 @@ import { Client } from "elasticsearch";
 import {
   AWS_ELASTIC_ACCESS_KEY,
   AWS_ELASTIC_SECRET_KEY,
+  AWS_ELASTIC_REGION,
   AWS_ELASTIC_HOST
 } from "../config";
 import { ErrorCode } from "../interfaces/enum";
@@ -13,7 +14,7 @@ AWS.config.update({
     AWS_ELASTIC_ACCESS_KEY,
     AWS_ELASTIC_SECRET_KEY
   ),
-  region: "eu-west-3"
+  region: AWS_ELASTIC_REGION
 });
 
 export const elasticSearch = new Client({


### PR DESCRIPTION
I noticed that the AWS elastic region was hardcoded. You could extract it automatically from the URI but I think this is more in line with how you're handling SES.

Also (but feel free to take it out), preventing people from committing their .env is probably a good idea.