### PR TITLE
Matching to schema.sql

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ DB_PORT = 3306
 DB_USERNAME = "root"
 DB_PASSWORD = ""
 DB_DATABASE = "database-name"
-DB_TABLE_PREFIX = ""
+DB_TABLE_PREFIX = "staart-"
 
 # Sending emails via AWS SES
 SES_EMAIL = "staart@o15y.com"


### PR DESCRIPTION
Since `schema.sql` generates tables starting with `staart-` as the prefix, it is fair to assume that users will use the example `.env` as well. 