### PR TITLE
:sparkles: Add hash IDs instead of integer IDs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,8 @@ AWS_ELASTIC_ACCESS_KEY = "aws-access-key-xxxxxxxxxx"
 AWS_ELASTIC_SECRET_KEY = "aws-secret-key-xxxxxxxxxx"
 AWS_ELASTIC_HOST = "https://name.region.es.amazonaws.com"
 AWS_ELASTIC_REGION = "eu-west-2"
+ELASTIC_LOGS_PREFIX = "staart-logs-"
+ELASTIC_EVENTS_PREFIX = "staart-events-"
 
 ##################################
 # Optional environment variables #

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ FRONTEND_URL = "http://localhost:3000" # URL for Staart UI
 JWT_SECRET = "staart"
 JWT_ISSUER = "staart"
 SERVICE_2FA = "staart"
+HASH_IDS = "staart"
 
 # MySQL/MariaDB connection
 DB_HOST = "localhost"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "staart-manager",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "main": "index.js",
   "repository": "git@github.com:AnandChowdhary/staart.git",
   "author": "Anand Chowdhary <mail@anandchowdhary.com>",
@@ -114,6 +114,7 @@
     "fs-extra": "^8.1.0",
     "geolite2": "^1.2.1",
     "handy-redis": "^1.6.2",
+    "hashids": "^2.0.0",
     "helmet": "^3.20.1",
     "http-aws-es": "^6.0.0",
     "http-status-codes": "^1.3.2",
@@ -146,5 +147,5 @@
     "setup"
   ],
   "snyk": true,
-  "staart-version": "1.1.9"
+  "staart-version": "1.1.10"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "staart-manager",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "main": "index.js",
   "repository": "git@github.com:AnandChowdhary/staart.git",
   "author": "Anand Chowdhary <mail@anandchowdhary.com>",
@@ -147,5 +147,5 @@
     "setup"
   ],
   "snyk": true,
-  "staart-version": "1.1.16"
+  "staart-version": "1.1.17"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "staart-manager",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "main": "index.js",
   "repository": "git@github.com:AnandChowdhary/staart.git",
   "author": "Anand Chowdhary <mail@anandchowdhary.com>",
@@ -147,5 +147,5 @@
     "setup"
   ],
   "snyk": true,
-  "staart-version": "1.1.14"
+  "staart-version": "1.1.15"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "staart-manager",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "main": "index.js",
   "repository": "git@github.com:AnandChowdhary/staart.git",
   "author": "Anand Chowdhary <mail@anandchowdhary.com>",
@@ -147,5 +147,5 @@
     "setup"
   ],
   "snyk": true,
-  "staart-version": "1.1.11"
+  "staart-version": "1.1.12"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "staart-manager",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "main": "index.js",
   "repository": "git@github.com:AnandChowdhary/staart.git",
   "author": "Anand Chowdhary <mail@anandchowdhary.com>",
@@ -147,5 +147,5 @@
     "setup"
   ],
   "snyk": true,
-  "staart-version": "1.1.13"
+  "staart-version": "1.1.14"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "staart-manager",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "main": "index.js",
   "repository": "git@github.com:AnandChowdhary/staart.git",
   "author": "Anand Chowdhary <mail@anandchowdhary.com>",
@@ -147,5 +147,5 @@
     "setup"
   ],
   "snyk": true,
-  "staart-version": "1.1.12"
+  "staart-version": "1.1.13"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "staart-manager",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "main": "index.js",
   "repository": "git@github.com:AnandChowdhary/staart.git",
   "author": "Anand Chowdhary <mail@anandchowdhary.com>",
@@ -147,5 +147,5 @@
     "setup"
   ],
   "snyk": true,
-  "staart-version": "1.1.10"
+  "staart-version": "1.1.11"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "staart-manager",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "main": "index.js",
   "repository": "git@github.com:AnandChowdhary/staart.git",
   "author": "Anand Chowdhary <mail@anandchowdhary.com>",
@@ -147,5 +147,5 @@
     "setup"
   ],
   "snyk": true,
-  "staart-version": "1.1.15"
+  "staart-version": "1.1.16"
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -106,3 +106,7 @@ export const AWS_ELASTIC_ACCESS_KEY = process.env.AWS_ELASTIC_ACCESS_KEY || "";
 export const AWS_ELASTIC_SECRET_KEY = process.env.AWS_ELASTIC_SECRET_KEY || "";
 export const AWS_ELASTIC_HOST = process.env.AWS_ELASTIC_HOST || "";
 export const AWS_ELASTIC_REGION = process.env.AWS_ELASTIC_REGION || "";
+export const ELASTIC_LOGS_PREFIX =
+  process.env.ELASTIC_LOGS_PREFIX || "staart-logs-";
+export const ELASTIC_EVENTS_PREFIX =
+  process.env.ELASTIC_EVENTS_PREFIX || "staart-events-";

--- a/src/config.ts
+++ b/src/config.ts
@@ -67,6 +67,7 @@ export const ALLOW_DISPOSABLE_EMAILS = !!process.env.DISPOSABLE_EMAIL;
 export const JWT_SECRET = process.env.JWT_SECRET || "staart";
 export const JWT_ISSUER = process.env.JWT_ISSUER || "staart";
 export const SERVICE_2FA = process.env.SERVICE_2FA || "staart";
+export const HASH_IDS = process.env.HASH_IDS || "staart";
 
 export const TOKEN_EXPIRY_EMAIL_VERIFICATION =
   process.env.TOKEN_EXPIRY_EMAIL_VERIFICATION || "7d";

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,6 +68,7 @@ export const JWT_SECRET = process.env.JWT_SECRET || "staart";
 export const JWT_ISSUER = process.env.JWT_ISSUER || "staart";
 export const SERVICE_2FA = process.env.SERVICE_2FA || "staart";
 export const HASH_IDS = process.env.HASH_IDS || "staart";
+export const HASH_ID_PREFIX = process.env.HASH_ID_PREFIX || "d0e8a7c-";
 
 export const TOKEN_EXPIRY_EMAIL_VERIFICATION =
   process.env.TOKEN_EXPIRY_EMAIL_VERIFICATION || "7d";

--- a/src/controllers/v1/auth.ts
+++ b/src/controllers/v1/auth.ts
@@ -219,7 +219,7 @@ export class AuthController {
   @Post("impersonate/:id")
   @Middleware(authHandler)
   @Middleware(
-    validator({ impersonateUserId: Joi.number().required() }, "params")
+    validator({ impersonateUserId: Joi.string().required() }, "params")
   )
   async getImpersonate(req: Request, res: Response) {
     const tokenUserId = res.locals.token.id;

--- a/src/controllers/v1/auth.ts
+++ b/src/controllers/v1/auth.ts
@@ -28,7 +28,7 @@ import {
 } from "../../helpers/middleware";
 import { CREATED } from "http-status-codes";
 import asyncHandler from "express-async-handler";
-import { safeRedirect, joiValidate } from "../../helpers/utils";
+import { safeRedirect, joiValidate, hashIdToId } from "../../helpers/utils";
 import Joi from "@hapi/joi";
 import { FRONTEND_URL, BASE_URL } from "../../config";
 import {
@@ -223,7 +223,7 @@ export class AuthController {
   )
   async getImpersonate(req: Request, res: Response) {
     const tokenUserId = res.locals.token.id;
-    const impersonateUserId = parseInt(req.params.id);
+    const impersonateUserId = hashIdToId(req.params.id);
     res.json(await impersonate(tokenUserId, impersonateUserId, res.locals));
   }
 

--- a/src/controllers/v1/membership.ts
+++ b/src/controllers/v1/membership.ts
@@ -17,6 +17,7 @@ import {
 import { authHandler, validator } from "../../helpers/middleware";
 import asyncHandler from "express-async-handler";
 import Joi from "@hapi/joi";
+import { hashIdToId } from "../../helpers/utils";
 
 @Controller("v1/memberships")
 @ClassWrapper(asyncHandler)
@@ -25,7 +26,7 @@ export class MembershipController {
   @Get(":id")
   @Middleware(validator({ id: Joi.string().required() }, "params"))
   async get(req: Request, res: Response) {
-    const membershipId = parseInt(req.params.id);
+    const membershipId = hashIdToId(req.params.id);
     const userId = res.locals.token.id;
     res.json(await getMembershipDetailsForUser(userId, membershipId));
   }
@@ -34,7 +35,7 @@ export class MembershipController {
   @Middleware(validator({ id: Joi.string().required() }, "params"))
   async delete(req: Request, res: Response) {
     const userId = res.locals.token.id;
-    const membershipId = parseInt(req.params.id);
+    const membershipId = hashIdToId(req.params.id);
     await deleteMembershipForUser(userId, membershipId, res.locals);
     res.json({ deleted: true });
   }
@@ -43,7 +44,7 @@ export class MembershipController {
   @Middleware(validator({ id: Joi.string().required() }, "params"))
   async patch(req: Request, res: Response) {
     const userId = res.locals.token.id;
-    const membershipId = parseInt(req.params.id);
+    const membershipId = hashIdToId(req.params.id);
     const data = req.body;
     delete req.body.id;
     await updateMembershipForUser(userId, membershipId, data, res.locals);

--- a/src/controllers/v1/membership.ts
+++ b/src/controllers/v1/membership.ts
@@ -23,7 +23,7 @@ import Joi from "@hapi/joi";
 @ClassMiddleware(authHandler)
 export class MembershipController {
   @Get(":id")
-  @Middleware(validator({ id: Joi.number().required() }, "params"))
+  @Middleware(validator({ id: Joi.string().required() }, "params"))
   async get(req: Request, res: Response) {
     const membershipId = parseInt(req.params.id);
     const userId = res.locals.token.id;
@@ -31,7 +31,7 @@ export class MembershipController {
   }
 
   @Delete(":id")
-  @Middleware(validator({ id: Joi.number().required() }, "params"))
+  @Middleware(validator({ id: Joi.string().required() }, "params"))
   async delete(req: Request, res: Response) {
     const userId = res.locals.token.id;
     const membershipId = parseInt(req.params.id);
@@ -40,7 +40,7 @@ export class MembershipController {
   }
 
   @Patch(":id")
-  @Middleware(validator({ id: Joi.number().required() }, "params"))
+  @Middleware(validator({ id: Joi.string().required() }, "params"))
   async patch(req: Request, res: Response) {
     const userId = res.locals.token.id;
     const membershipId = parseInt(req.params.id);

--- a/src/controllers/v1/organization.ts
+++ b/src/controllers/v1/organization.ts
@@ -87,7 +87,7 @@ export class OrganizationController {
   @Get(":id")
   async get(req: Request, res: Response) {
     const id = await organizationUsernameToId(req.params.id);
-    joiValidate({ id: Joi.number().required() }, { id });
+    joiValidate({ id: Joi.string().required() }, { id });
     const organization = await getOrganizationForUser(
       localsToTokenOrKey(res),
       id
@@ -112,7 +112,7 @@ export class OrganizationController {
   )
   async patch(req: Request, res: Response) {
     const id = await organizationUsernameToId(req.params.id);
-    joiValidate({ id: Joi.number().required() }, { id });
+    joiValidate({ id: Joi.string().required() }, { id });
     await updateOrganizationForUser(
       localsToTokenOrKey(res),
       id,
@@ -126,7 +126,7 @@ export class OrganizationController {
   async delete(req: Request, res: Response) {
     const organizationId = await organizationUsernameToId(req.params.id);
     joiValidate(
-      { organizationId: Joi.number().required() },
+      { organizationId: Joi.string().required() },
       { organizationId }
     );
     await deleteOrganizationForUser(
@@ -141,7 +141,7 @@ export class OrganizationController {
   async getBilling(req: Request, res: Response) {
     const organizationId = await organizationUsernameToId(req.params.id);
     joiValidate(
-      { organizationId: Joi.number().required() },
+      { organizationId: Joi.string().required() },
       { organizationId }
     );
     res.json(
@@ -156,7 +156,7 @@ export class OrganizationController {
   async patchBilling(req: Request, res: Response) {
     const organizationId = await organizationUsernameToId(req.params.id);
     joiValidate(
-      { organizationId: Joi.number().required() },
+      { organizationId: Joi.string().required() },
       { organizationId }
     );
     await updateOrganizationBillingForUser(
@@ -172,7 +172,7 @@ export class OrganizationController {
   async getInvoices(req: Request, res: Response) {
     const organizationId = await organizationUsernameToId(req.params.id);
     joiValidate(
-      { organizationId: Joi.number().required() },
+      { organizationId: Joi.string().required() },
       { organizationId }
     );
     const subscriptionParams = { ...req.query };
@@ -201,7 +201,7 @@ export class OrganizationController {
     const invoiceId = req.params.invoiceId;
     joiValidate(
       {
-        organizationId: Joi.number().required(),
+        organizationId: Joi.string().required(),
         invoiceId: Joi.string().required()
       },
       { organizationId, invoiceId }
@@ -219,7 +219,7 @@ export class OrganizationController {
   async getSources(req: Request, res: Response) {
     const organizationId = await organizationUsernameToId(req.params.id);
     joiValidate(
-      { organizationId: Joi.number().required() },
+      { organizationId: Joi.string().required() },
       { organizationId }
     );
     const subscriptionParams = { ...req.query };
@@ -245,7 +245,7 @@ export class OrganizationController {
     const sourceId = req.params.sourceId;
     joiValidate(
       {
-        organizationId: Joi.number().required(),
+        organizationId: Joi.string().required(),
         sourceId: Joi.string().required()
       },
       { organizationId, sourceId }
@@ -263,7 +263,7 @@ export class OrganizationController {
   async getSubscriptions(req: Request, res: Response) {
     const organizationId = await organizationUsernameToId(req.params.id);
     joiValidate(
-      { organizationId: Joi.number().required() },
+      { organizationId: Joi.string().required() },
       { organizationId }
     );
     const subscriptionParams = { ...req.query };
@@ -292,7 +292,7 @@ export class OrganizationController {
     const subscriptionId = req.params.subscriptionId;
     joiValidate(
       {
-        organizationId: Joi.number().required(),
+        organizationId: Joi.string().required(),
         subscriptionId: Joi.string().required()
       },
       { organizationId, subscriptionId }
@@ -313,7 +313,7 @@ export class OrganizationController {
     const data = req.body;
     joiValidate(
       {
-        organizationId: Joi.number().required(),
+        organizationId: Joi.string().required(),
         subscriptionId: Joi.string().required()
       },
       { organizationId, subscriptionId }
@@ -342,7 +342,7 @@ export class OrganizationController {
   async putSubscriptions(req: Request, res: Response) {
     const organizationId = await organizationUsernameToId(req.params.id);
     joiValidate(
-      { organizationId: Joi.number().required() },
+      { organizationId: Joi.string().required() },
       { organizationId }
     );
     const subscriptionParams = { ...req.body };
@@ -370,7 +370,7 @@ export class OrganizationController {
     const organizationId = await organizationUsernameToId(req.params.id);
     joiValidate(
       {
-        organizationId: Joi.number().required()
+        organizationId: Joi.string().required()
       },
       { organizationId }
     );
@@ -386,7 +386,7 @@ export class OrganizationController {
   async putSources(req: Request, res: Response) {
     const organizationId = await organizationUsernameToId(req.params.id);
     joiValidate(
-      { organizationId: Joi.number().required() },
+      { organizationId: Joi.string().required() },
       { organizationId }
     );
     res
@@ -407,7 +407,7 @@ export class OrganizationController {
     const organizationId = await organizationUsernameToId(req.params.id);
     joiValidate(
       {
-        organizationId: Joi.number().required(),
+        organizationId: Joi.string().required(),
         sourceId: Joi.string().required()
       },
       { organizationId, sourceId }
@@ -428,7 +428,7 @@ export class OrganizationController {
     const organizationId = await organizationUsernameToId(req.params.id);
     joiValidate(
       {
-        organizationId: Joi.number().required(),
+        organizationId: Joi.string().required(),
         sourceId: Joi.string().required()
       },
       { organizationId, sourceId }
@@ -448,7 +448,7 @@ export class OrganizationController {
   async getData(req: Request, res: Response) {
     const organizationId = await organizationUsernameToId(req.params.id);
     joiValidate(
-      { organizationId: Joi.number().required() },
+      { organizationId: Joi.string().required() },
       { organizationId }
     );
     res.json(
@@ -463,7 +463,7 @@ export class OrganizationController {
   async getMemberships(req: Request, res: Response) {
     const organizationId = await organizationUsernameToId(req.params.id);
     joiValidate(
-      { organizationId: Joi.number().required() },
+      { organizationId: Joi.string().required() },
       { organizationId }
     );
     res.json(
@@ -483,7 +483,7 @@ export class OrganizationController {
     const role = req.body.role;
     joiValidate(
       {
-        organizationId: Joi.number().required(),
+        organizationId: Joi.string().required(),
         newMemberName: Joi.string()
           .min(6)
           .required(),
@@ -516,8 +516,8 @@ export class OrganizationController {
     const membershipId = parseInt(req.params.membershipId);
     joiValidate(
       {
-        organizationId: Joi.number().required(),
-        membershipId: Joi.number().required()
+        organizationId: Joi.string().required(),
+        membershipId: Joi.string().required()
       },
       { organizationId, membershipId }
     );
@@ -546,8 +546,8 @@ export class OrganizationController {
     const membershipId = parseInt(req.params.membershipId);
     joiValidate(
       {
-        organizationId: Joi.number().required(),
-        membershipId: Joi.number().required()
+        organizationId: Joi.string().required(),
+        membershipId: Joi.string().required()
       },
       { organizationId, membershipId }
     );
@@ -567,8 +567,8 @@ export class OrganizationController {
     const membershipId = parseInt(req.params.membershipId);
     joiValidate(
       {
-        organizationId: Joi.number().required(),
-        membershipId: Joi.number().required()
+        organizationId: Joi.string().required(),
+        membershipId: Joi.string().required()
       },
       { organizationId, membershipId }
     );
@@ -585,7 +585,7 @@ export class OrganizationController {
   async getUserApiKeys(req: Request, res: Response) {
     const id = await organizationUsernameToId(req.params.id);
     joiValidate(
-      { id: [Joi.string().required(), Joi.number().required()] },
+      { id: [Joi.string().required(), Joi.string().required()] },
       { id }
     );
     const apiKeyParams = { ...req.query };
@@ -621,7 +621,7 @@ export class OrganizationController {
   async putUserApiKeys(req: Request, res: Response) {
     const id = await organizationUsernameToId(req.params.id);
     joiValidate(
-      { id: [Joi.string().required(), Joi.number().required()] },
+      { id: [Joi.string().required(), Joi.string().required()] },
       { id }
     );
     res
@@ -642,8 +642,8 @@ export class OrganizationController {
     const apiKeyId = parseInt(req.params.apiKeyId);
     joiValidate(
       {
-        id: [Joi.string().required(), Joi.number().required()],
-        apiKeyId: Joi.number().required()
+        id: [Joi.string().required(), Joi.string().required()],
+        apiKeyId: Joi.string().required()
       },
       { id, apiKeyId }
     );
@@ -670,8 +670,8 @@ export class OrganizationController {
     const apiKeyId = parseInt(req.params.apiKeyId);
     joiValidate(
       {
-        id: [Joi.string().required(), Joi.number().required()],
-        apiKeyId: Joi.number().required()
+        id: [Joi.string().required(), Joi.string().required()],
+        apiKeyId: Joi.string().required()
       },
       { id, apiKeyId }
     );
@@ -692,8 +692,8 @@ export class OrganizationController {
     const apiKeyId = parseInt(req.params.apiKeyId);
     joiValidate(
       {
-        id: [Joi.string().required(), Joi.number().required()],
-        apiKeyId: Joi.number().required()
+        id: [Joi.string().required(), Joi.string().required()],
+        apiKeyId: Joi.string().required()
       },
       { id, apiKeyId }
     );
@@ -713,8 +713,8 @@ export class OrganizationController {
     const apiKeyId = parseInt(req.params.apiKeyId);
     joiValidate(
       {
-        id: [Joi.string().required(), Joi.number().required()],
-        apiKeyId: Joi.number().required()
+        id: [Joi.string().required(), Joi.string().required()],
+        apiKeyId: Joi.string().required()
       },
       { id, apiKeyId }
     );
@@ -732,7 +732,7 @@ export class OrganizationController {
   async getUserDomains(req: Request, res: Response) {
     const id = await organizationUsernameToId(req.params.id);
     joiValidate(
-      { id: [Joi.string().required(), Joi.number().required()] },
+      { id: [Joi.string().required(), Joi.string().required()] },
       { id }
     );
     const domainParams = { ...req.query };
@@ -764,7 +764,7 @@ export class OrganizationController {
   async putUserDomains(req: Request, res: Response) {
     const id = await organizationUsernameToId(req.params.id);
     joiValidate(
-      { id: [Joi.string().required(), Joi.number().required()] },
+      { id: [Joi.string().required(), Joi.string().required()] },
       { id }
     );
     res
@@ -785,8 +785,8 @@ export class OrganizationController {
     const domainId = parseInt(req.params.domainId);
     joiValidate(
       {
-        id: [Joi.string().required(), Joi.number().required()],
-        domainId: Joi.number().required()
+        id: [Joi.string().required(), Joi.string().required()],
+        domainId: Joi.string().required()
       },
       { id, domainId }
     );
@@ -809,8 +809,8 @@ export class OrganizationController {
     const domainId = parseInt(req.params.domainId);
     joiValidate(
       {
-        id: [Joi.string().required(), Joi.number().required()],
-        domainId: Joi.number().required()
+        id: [Joi.string().required(), Joi.string().required()],
+        domainId: Joi.string().required()
       },
       { id, domainId }
     );
@@ -831,8 +831,8 @@ export class OrganizationController {
     const domainId = parseInt(req.params.domainId);
     joiValidate(
       {
-        id: [Joi.string().required(), Joi.number().required()],
-        domainId: Joi.number().required()
+        id: [Joi.string().required(), Joi.string().required()],
+        domainId: Joi.string().required()
       },
       { id, domainId }
     );
@@ -853,8 +853,8 @@ export class OrganizationController {
     const method = req.body.method || req.query.method;
     joiValidate(
       {
-        id: [Joi.string().required(), Joi.number().required()],
-        domainId: Joi.number().required(),
+        id: [Joi.string().required(), Joi.string().required()],
+        domainId: Joi.string().required(),
         method: Joi.string().only(["file", "dns"])
       },
       { id, domainId, method }
@@ -874,7 +874,7 @@ export class OrganizationController {
   async getUserWebhooks(req: Request, res: Response) {
     const id = await organizationUsernameToId(req.params.id);
     joiValidate(
-      { id: [Joi.string().required(), Joi.number().required()] },
+      { id: [Joi.string().required(), Joi.string().required()] },
       { id }
     );
     const webhookParams = { ...req.query };
@@ -910,7 +910,7 @@ export class OrganizationController {
   async putUserWebhooks(req: Request, res: Response) {
     const id = await organizationUsernameToId(req.params.id);
     joiValidate(
-      { id: [Joi.string().required(), Joi.number().required()] },
+      { id: [Joi.string().required(), Joi.string().required()] },
       { id }
     );
     res
@@ -931,8 +931,8 @@ export class OrganizationController {
     const webhookId = parseInt(req.params.webhookId);
     joiValidate(
       {
-        id: [Joi.string().required(), Joi.number().required()],
-        webhookId: Joi.number().required()
+        id: [Joi.string().required(), Joi.string().required()],
+        webhookId: Joi.string().required()
       },
       { id, webhookId }
     );
@@ -963,8 +963,8 @@ export class OrganizationController {
     const webhookId = parseInt(req.params.webhookId);
     joiValidate(
       {
-        id: [Joi.string().required(), Joi.number().required()],
-        webhookId: Joi.number().required()
+        id: [Joi.string().required(), Joi.string().required()],
+        webhookId: Joi.string().required()
       },
       { id, webhookId }
     );
@@ -985,8 +985,8 @@ export class OrganizationController {
     const webhookId = parseInt(req.params.webhookId);
     joiValidate(
       {
-        id: [Joi.string().required(), Joi.number().required()],
-        webhookId: Joi.number().required()
+        id: [Joi.string().required(), Joi.string().required()],
+        webhookId: Joi.string().required()
       },
       { id, webhookId }
     );

--- a/src/controllers/v1/organization.ts
+++ b/src/controllers/v1/organization.ts
@@ -60,7 +60,8 @@ import asyncHandler from "express-async-handler";
 import {
   joiValidate,
   organizationUsernameToId,
-  localsToTokenOrKey
+  localsToTokenOrKey,
+  hashIdToId
 } from "../../helpers/utils";
 import Joi from "@hapi/joi";
 
@@ -513,7 +514,7 @@ export class OrganizationController {
   @Get(":id/memberships/:membershipId")
   async getMembership(req: Request, res: Response) {
     const organizationId = await organizationUsernameToId(req.params.id);
-    const membershipId = parseInt(req.params.membershipId);
+    const membershipId = hashIdToId(req.params.membershipId);
     joiValidate(
       {
         organizationId: Joi.string().required(),
@@ -543,7 +544,7 @@ export class OrganizationController {
   )
   async updateMembership(req: Request, res: Response) {
     const organizationId = await organizationUsernameToId(req.params.id);
-    const membershipId = parseInt(req.params.membershipId);
+    const membershipId = hashIdToId(req.params.membershipId);
     joiValidate(
       {
         organizationId: Joi.string().required(),
@@ -564,7 +565,7 @@ export class OrganizationController {
   @Delete(":id/memberships/:membershipId")
   async deleteMembership(req: Request, res: Response) {
     const organizationId = await organizationUsernameToId(req.params.id);
-    const membershipId = parseInt(req.params.membershipId);
+    const membershipId = hashIdToId(req.params.membershipId);
     joiValidate(
       {
         organizationId: Joi.string().required(),
@@ -639,7 +640,7 @@ export class OrganizationController {
   @Get(":id/api-keys/:apiKeyId")
   async getUserApiKey(req: Request, res: Response) {
     const id = await organizationUsernameToId(req.params.id);
-    const apiKeyId = parseInt(req.params.apiKeyId);
+    const apiKeyId = hashIdToId(req.params.apiKeyId);
     joiValidate(
       {
         id: [Joi.string().required(), Joi.string().required()],
@@ -667,7 +668,7 @@ export class OrganizationController {
   )
   async patchUserApiKey(req: Request, res: Response) {
     const id = await organizationUsernameToId(req.params.id);
-    const apiKeyId = parseInt(req.params.apiKeyId);
+    const apiKeyId = hashIdToId(req.params.apiKeyId);
     joiValidate(
       {
         id: [Joi.string().required(), Joi.string().required()],
@@ -689,7 +690,7 @@ export class OrganizationController {
   @Delete(":id/api-keys/:apiKeyId")
   async deleteUserApiKey(req: Request, res: Response) {
     const id = await organizationUsernameToId(req.params.id);
-    const apiKeyId = parseInt(req.params.apiKeyId);
+    const apiKeyId = hashIdToId(req.params.apiKeyId);
     joiValidate(
       {
         id: [Joi.string().required(), Joi.string().required()],
@@ -710,7 +711,7 @@ export class OrganizationController {
   @Get(":id/api-keys/:apiKeyId/logs")
   async getUserApiKeyLogs(req: Request, res: Response) {
     const id = await organizationUsernameToId(req.params.id);
-    const apiKeyId = parseInt(req.params.apiKeyId);
+    const apiKeyId = hashIdToId(req.params.apiKeyId);
     joiValidate(
       {
         id: [Joi.string().required(), Joi.string().required()],
@@ -782,7 +783,7 @@ export class OrganizationController {
   @Get(":id/domains/:domainId")
   async getUserDomain(req: Request, res: Response) {
     const id = await organizationUsernameToId(req.params.id);
-    const domainId = parseInt(req.params.domainId);
+    const domainId = hashIdToId(req.params.domainId);
     joiValidate(
       {
         id: [Joi.string().required(), Joi.string().required()],
@@ -806,7 +807,7 @@ export class OrganizationController {
   )
   async patchUserDomain(req: Request, res: Response) {
     const id = await organizationUsernameToId(req.params.id);
-    const domainId = parseInt(req.params.domainId);
+    const domainId = hashIdToId(req.params.domainId);
     joiValidate(
       {
         id: [Joi.string().required(), Joi.string().required()],
@@ -828,7 +829,7 @@ export class OrganizationController {
   @Delete(":id/domains/:domainId")
   async deleteUserDomain(req: Request, res: Response) {
     const id = await organizationUsernameToId(req.params.id);
-    const domainId = parseInt(req.params.domainId);
+    const domainId = hashIdToId(req.params.domainId);
     joiValidate(
       {
         id: [Joi.string().required(), Joi.string().required()],
@@ -849,7 +850,7 @@ export class OrganizationController {
   @Post(":id/domains/:domainId/verify")
   async verifyOrganizationDomain(req: Request, res: Response) {
     const id = await organizationUsernameToId(req.params.id);
-    const domainId = parseInt(req.params.domainId);
+    const domainId = hashIdToId(req.params.domainId);
     const method = req.body.method || req.query.method;
     joiValidate(
       {
@@ -928,7 +929,7 @@ export class OrganizationController {
   @Get(":id/webhooks/:webhookId")
   async getUserWebhook(req: Request, res: Response) {
     const id = await organizationUsernameToId(req.params.id);
-    const webhookId = parseInt(req.params.webhookId);
+    const webhookId = hashIdToId(req.params.webhookId);
     joiValidate(
       {
         id: [Joi.string().required(), Joi.string().required()],
@@ -960,7 +961,7 @@ export class OrganizationController {
   )
   async patchUserWebhook(req: Request, res: Response) {
     const id = await organizationUsernameToId(req.params.id);
-    const webhookId = parseInt(req.params.webhookId);
+    const webhookId = hashIdToId(req.params.webhookId);
     joiValidate(
       {
         id: [Joi.string().required(), Joi.string().required()],
@@ -982,7 +983,7 @@ export class OrganizationController {
   @Delete(":id/webhooks/:webhookId")
   async deleteUserWebhook(req: Request, res: Response) {
     const id = await organizationUsernameToId(req.params.id);
-    const webhookId = parseInt(req.params.webhookId);
+    const webhookId = hashIdToId(req.params.webhookId);
     joiValidate(
       {
         id: [Joi.string().required(), Joi.string().required()],

--- a/src/controllers/v1/user.ts
+++ b/src/controllers/v1/user.ts
@@ -58,7 +58,7 @@ export class UserController {
   async get(req: Request, res: Response) {
     const id = await userUsernameToId(req.params.id, res.locals.token.id);
     joiValidate(
-      { id: [Joi.string().required(), Joi.number().required()] },
+      { id: [Joi.string().required(), Joi.string().required()] },
       { id }
     );
     res.json(await getUserFromId(id, res.locals.token.id));
@@ -93,7 +93,7 @@ export class UserController {
   async patch(req: Request, res: Response) {
     const id = await userUsernameToId(req.params.id, res.locals.token.id);
     joiValidate(
-      { id: [Joi.string().required(), Joi.number().required()] },
+      { id: [Joi.string().required(), Joi.string().required()] },
       { id }
     );
     await updateUserForUser(res.locals.token.id, id, req.body, res.locals);
@@ -104,7 +104,7 @@ export class UserController {
   async delete(req: Request, res: Response) {
     const id = await userUsernameToId(req.params.id, res.locals.token.id);
     joiValidate(
-      { id: [Joi.string().required(), Joi.number().required()] },
+      { id: [Joi.string().required(), Joi.string().required()] },
       { id }
     );
     res.json(await deleteUserForUser(res.locals.token.id, id, res.locals));
@@ -130,7 +130,7 @@ export class UserController {
     const newPassword = req.body.newPassword;
     joiValidate(
       {
-        id: [Joi.string().required(), Joi.number().required()]
+        id: [Joi.string().required(), Joi.string().required()]
       },
       { id }
     );
@@ -148,7 +148,7 @@ export class UserController {
   async getRecentEvents(req: Request, res: Response) {
     const id = await userUsernameToId(req.params.id, res.locals.token.id);
     joiValidate(
-      { id: [Joi.string().required(), Joi.number().required()] },
+      { id: [Joi.string().required(), Joi.string().required()] },
       { id }
     );
     res.json(await getRecentEventsForUser(res.locals.token.id, id, req.query));
@@ -158,7 +158,7 @@ export class UserController {
   async getMemberships(req: Request, res: Response) {
     const id = await userUsernameToId(req.params.id, res.locals.token.id);
     joiValidate(
-      { id: [Joi.string().required(), Joi.number().required()] },
+      { id: [Joi.string().required(), Joi.string().required()] },
       { id }
     );
     res.json(await getMembershipsForUser(res.locals.token.id, id, req.query));
@@ -170,8 +170,8 @@ export class UserController {
     const membershipId = parseInt(req.params.membershipId);
     joiValidate(
       {
-        id: [Joi.string().required(), Joi.number().required()],
-        membershipId: Joi.number().required()
+        id: [Joi.string().required(), Joi.string().required()],
+        membershipId: Joi.string().required()
       },
       { id, membershipId }
     );
@@ -184,8 +184,8 @@ export class UserController {
     const membershipId = parseInt(req.params.membershipId);
     joiValidate(
       {
-        id: [Joi.string().required(), Joi.number().required()],
-        membershipId: Joi.number().required()
+        id: [Joi.string().required(), Joi.string().required()],
+        membershipId: Joi.string().required()
       },
       { id, membershipId }
     );
@@ -199,8 +199,8 @@ export class UserController {
     const membershipId = parseInt(req.params.membershipId);
     joiValidate(
       {
-        id: [Joi.string().required(), Joi.number().required()],
-        membershipId: Joi.number().required()
+        id: [Joi.string().required(), Joi.string().required()],
+        membershipId: Joi.string().required()
       },
       { id, membershipId }
     );
@@ -214,7 +214,7 @@ export class UserController {
   async getUserData(req: Request, res: Response) {
     const id = await userUsernameToId(req.params.id, res.locals.token.id);
     joiValidate(
-      { id: [Joi.string().required(), Joi.number().required()] },
+      { id: [Joi.string().required(), Joi.string().required()] },
       { id }
     );
     res.json(await getAllDataForUser(res.locals.token.id, id));
@@ -224,7 +224,7 @@ export class UserController {
   async getEmails(req: Request, res: Response) {
     const id = await userUsernameToId(req.params.id, res.locals.token.id);
     joiValidate(
-      { id: [Joi.string().required(), Joi.number().required()] },
+      { id: [Joi.string().required(), Joi.string().required()] },
       { id }
     );
     res.json(await getAllEmailsForUser(res.locals.token.id, id, req.query));
@@ -236,7 +236,7 @@ export class UserController {
     const email = req.body.email;
     joiValidate(
       {
-        id: [Joi.string().required(), Joi.number().required()],
+        id: [Joi.string().required(), Joi.string().required()],
         email: Joi.string()
           .email()
           .required()
@@ -253,8 +253,8 @@ export class UserController {
     const emailId = parseInt(req.params.emailId);
     joiValidate(
       {
-        id: [Joi.string().required(), Joi.number().required()],
-        emailId: Joi.number().required()
+        id: [Joi.string().required(), Joi.string().required()],
+        emailId: Joi.string().required()
       },
       { id, emailId }
     );
@@ -267,8 +267,8 @@ export class UserController {
     const emailId = parseInt(req.params.emailId);
     joiValidate(
       {
-        id: [Joi.string().required(), Joi.number().required()],
-        emailId: Joi.number().required()
+        id: [Joi.string().required(), Joi.string().required()],
+        emailId: Joi.string().required()
       },
       { id, emailId }
     );
@@ -282,8 +282,8 @@ export class UserController {
     const emailId = parseInt(req.params.emailId);
     joiValidate(
       {
-        id: [Joi.string().required(), Joi.number().required()],
-        emailId: Joi.number().required()
+        id: [Joi.string().required(), Joi.string().required()],
+        emailId: Joi.string().required()
       },
       { id, emailId }
     );
@@ -300,7 +300,7 @@ export class UserController {
   async getEnable2FA(req: Request, res: Response) {
     const id = await userUsernameToId(req.params.id, res.locals.token.id);
     joiValidate(
-      { id: [Joi.string().required(), Joi.number().required()] },
+      { id: [Joi.string().required(), Joi.string().required()] },
       { id }
     );
     res.json(await enable2FAForUser(res.locals.token.id, id));
@@ -312,7 +312,7 @@ export class UserController {
     const code = req.body.code;
     joiValidate(
       {
-        id: [Joi.string().required(), Joi.number().required()],
+        id: [Joi.string().required(), Joi.string().required()],
         code: Joi.number()
           .min(5)
           .required()
@@ -326,7 +326,7 @@ export class UserController {
   async delete2FA(req: Request, res: Response) {
     const id = await userUsernameToId(req.params.id, res.locals.token.id);
     joiValidate(
-      { id: [Joi.string().required(), Joi.number().required()] },
+      { id: [Joi.string().required(), Joi.string().required()] },
       { id }
     );
     res.json(await disable2FAForUser(res.locals.token.id, id));
@@ -336,7 +336,7 @@ export class UserController {
   async getBackupCodes(req: Request, res: Response) {
     const id = await userUsernameToId(req.params.id, res.locals.token.id);
     joiValidate(
-      { id: [Joi.string().required(), Joi.number().required()] },
+      { id: [Joi.string().required(), Joi.string().required()] },
       { id }
     );
     res.json(await getBackupCodesForUser(res.locals.token.id, id));
@@ -346,7 +346,7 @@ export class UserController {
   async getRegenerateBackupCodes(req: Request, res: Response) {
     const id = await userUsernameToId(req.params.id, res.locals.token.id);
     joiValidate(
-      { id: [Joi.string().required(), Joi.number().required()] },
+      { id: [Joi.string().required(), Joi.string().required()] },
       { id }
     );
     res.json(await regenerateBackupCodesForUser(res.locals.token.id, id));
@@ -356,7 +356,7 @@ export class UserController {
   async getUserAccessTokens(req: Request, res: Response) {
     const id = await userUsernameToId(req.params.id, res.locals.token.id);
     joiValidate(
-      { id: [Joi.string().required(), Joi.number().required()] },
+      { id: [Joi.string().required(), Joi.string().required()] },
       { id }
     );
     const accessTokenParams = { ...req.query };
@@ -390,7 +390,7 @@ export class UserController {
   async putUserAccessTokens(req: Request, res: Response) {
     const id = await userUsernameToId(req.params.id, res.locals.token.id);
     joiValidate(
-      { id: [Joi.string().required(), Joi.number().required()] },
+      { id: [Joi.string().required(), Joi.string().required()] },
       { id }
     );
     res
@@ -411,8 +411,8 @@ export class UserController {
     const accessTokenId = parseInt(req.params.accessTokenId);
     joiValidate(
       {
-        id: [Joi.string().required(), Joi.number().required()],
-        accessTokenId: Joi.number().required()
+        id: [Joi.string().required(), Joi.string().required()],
+        accessTokenId: Joi.string().required()
       },
       { id, accessTokenId }
     );
@@ -437,8 +437,8 @@ export class UserController {
     const accessTokenId = parseInt(req.params.accessTokenId);
     joiValidate(
       {
-        id: [Joi.string().required(), Joi.number().required()],
-        accessTokenId: Joi.number().required()
+        id: [Joi.string().required(), Joi.string().required()],
+        accessTokenId: Joi.string().required()
       },
       { id, accessTokenId }
     );
@@ -459,8 +459,8 @@ export class UserController {
     const accessTokenId = parseInt(req.params.accessTokenId);
     joiValidate(
       {
-        id: [Joi.string().required(), Joi.number().required()],
-        accessTokenId: Joi.number().required()
+        id: [Joi.string().required(), Joi.string().required()],
+        accessTokenId: Joi.string().required()
       },
       { id, accessTokenId }
     );
@@ -478,7 +478,7 @@ export class UserController {
   async getUserSessions(req: Request, res: Response) {
     const id = await userUsernameToId(req.params.id, res.locals.token.id);
     joiValidate(
-      { id: [Joi.string().required(), Joi.number().required()] },
+      { id: [Joi.string().required(), Joi.string().required()] },
       { id }
     );
     const sessionParams = { ...req.query };
@@ -500,8 +500,8 @@ export class UserController {
     const sessionId = parseInt(req.params.sessionId);
     joiValidate(
       {
-        id: [Joi.string().required(), Joi.number().required()],
-        sessionId: Joi.number().required()
+        id: [Joi.string().required(), Joi.string().required()],
+        sessionId: Joi.string().required()
       },
       { id, sessionId }
     );
@@ -514,8 +514,8 @@ export class UserController {
     const sessionId = parseInt(req.params.sessionId);
     joiValidate(
       {
-        id: [Joi.string().required(), Joi.number().required()],
-        sessionId: Joi.number().required()
+        id: [Joi.string().required(), Joi.string().required()],
+        sessionId: Joi.string().required()
       },
       { id, sessionId }
     );

--- a/src/controllers/v1/user.ts
+++ b/src/controllers/v1/user.ts
@@ -73,7 +73,7 @@ export class UserController {
           .regex(/^[a-zA-Z ]*$/),
         username: Joi.string().regex(/^[a-z0-9\-]+$/i),
         nickname: Joi.string(),
-        primaryEmail: Joi.number(),
+        primaryEmail: Joi.string(),
         countryCode: Joi.string().length(2),
         password: Joi.string().min(6),
         gender: Joi.string().length(1),

--- a/src/controllers/v1/user.ts
+++ b/src/controllers/v1/user.ts
@@ -42,7 +42,7 @@ import {
 } from "../../rest/email";
 import { CREATED } from "http-status-codes";
 import asyncHandler from "express-async-handler";
-import { joiValidate, userUsernameToId } from "../../helpers/utils";
+import { joiValidate, userUsernameToId, hashIdToId } from "../../helpers/utils";
 import Joi from "@hapi/joi";
 import {
   deleteMembershipForUser,
@@ -167,7 +167,7 @@ export class UserController {
   @Get(":id/memberships/:membershipId")
   async getMembership(req: Request, res: Response) {
     const id = await userUsernameToId(req.params.id, res.locals.token.id);
-    const membershipId = parseInt(req.params.membershipId);
+    const membershipId = hashIdToId(req.params.membershipId);
     joiValidate(
       {
         id: [Joi.string().required(), Joi.string().required()],
@@ -181,7 +181,7 @@ export class UserController {
   @Delete(":id/memberships/:membershipId")
   async deleteMembership(req: Request, res: Response) {
     const id = await userUsernameToId(req.params.id, res.locals.token.id);
-    const membershipId = parseInt(req.params.membershipId);
+    const membershipId = hashIdToId(req.params.membershipId);
     joiValidate(
       {
         id: [Joi.string().required(), Joi.string().required()],
@@ -196,7 +196,7 @@ export class UserController {
   @Patch(":id/memberships/:membershipId")
   async updateMembership(req: Request, res: Response) {
     const id = await userUsernameToId(req.params.id, res.locals.token.id);
-    const membershipId = parseInt(req.params.membershipId);
+    const membershipId = hashIdToId(req.params.membershipId);
     joiValidate(
       {
         id: [Joi.string().required(), Joi.string().required()],
@@ -250,7 +250,7 @@ export class UserController {
   @Get(":id/emails/:emailId")
   async getEmail(req: Request, res: Response) {
     const id = await userUsernameToId(req.params.id, res.locals.token.id);
-    const emailId = parseInt(req.params.emailId);
+    const emailId = hashIdToId(req.params.emailId);
     joiValidate(
       {
         id: [Joi.string().required(), Joi.string().required()],
@@ -264,7 +264,7 @@ export class UserController {
   @Post(":id/emails/:emailId/resend")
   async postResend(req: Request, res: Response) {
     const id = await userUsernameToId(req.params.id, res.locals.token.id);
-    const emailId = parseInt(req.params.emailId);
+    const emailId = hashIdToId(req.params.emailId);
     joiValidate(
       {
         id: [Joi.string().required(), Joi.string().required()],
@@ -279,7 +279,7 @@ export class UserController {
   @Delete(":id/emails/:emailId")
   async deleteEmail(req: Request, res: Response) {
     const id = await userUsernameToId(req.params.id, res.locals.token.id);
-    const emailId = parseInt(req.params.emailId);
+    const emailId = hashIdToId(req.params.emailId);
     joiValidate(
       {
         id: [Joi.string().required(), Joi.string().required()],
@@ -408,7 +408,7 @@ export class UserController {
   @Get(":id/access-tokens/:accessTokenId")
   async getUserAccessToken(req: Request, res: Response) {
     const id = await userUsernameToId(req.params.id, res.locals.token.id);
-    const accessTokenId = parseInt(req.params.accessTokenId);
+    const accessTokenId = hashIdToId(req.params.accessTokenId);
     joiValidate(
       {
         id: [Joi.string().required(), Joi.string().required()],
@@ -434,7 +434,7 @@ export class UserController {
   )
   async patchUserAccessToken(req: Request, res: Response) {
     const id = await userUsernameToId(req.params.id, res.locals.token.id);
-    const accessTokenId = parseInt(req.params.accessTokenId);
+    const accessTokenId = hashIdToId(req.params.accessTokenId);
     joiValidate(
       {
         id: [Joi.string().required(), Joi.string().required()],
@@ -456,7 +456,7 @@ export class UserController {
   @Delete(":id/access-tokens/:accessTokenId")
   async deleteUserAccessToken(req: Request, res: Response) {
     const id = await userUsernameToId(req.params.id, res.locals.token.id);
-    const accessTokenId = parseInt(req.params.accessTokenId);
+    const accessTokenId = hashIdToId(req.params.accessTokenId);
     joiValidate(
       {
         id: [Joi.string().required(), Joi.string().required()],
@@ -497,7 +497,7 @@ export class UserController {
   @Get(":id/sessions/:sessionId")
   async getUserSession(req: Request, res: Response) {
     const id = await userUsernameToId(req.params.id, res.locals.token.id);
-    const sessionId = parseInt(req.params.sessionId);
+    const sessionId = hashIdToId(req.params.sessionId);
     joiValidate(
       {
         id: [Joi.string().required(), Joi.string().required()],
@@ -511,7 +511,7 @@ export class UserController {
   @Delete(":id/sessions/:sessionId")
   async deleteUserSession(req: Request, res: Response) {
     const id = await userUsernameToId(req.params.id, res.locals.token.id);
-    const sessionId = parseInt(req.params.sessionId);
+    const sessionId = hashIdToId(req.params.sessionId);
     joiValidate(
       {
         id: [Joi.string().required(), Joi.string().required()],

--- a/src/crons/minute.ts
+++ b/src/crons/minute.ts
@@ -7,6 +7,7 @@ import {
 } from "../helpers/tracking";
 import { elasticSearch } from "../helpers/elasticsearch";
 import { IdValues, hashIdToId } from "../helpers/utils";
+import { ELASTIC_EVENTS_PREFIX, ELASTIC_LOGS_PREFIX } from "../config";
 
 export default () => {
   new CronJob(
@@ -43,7 +44,7 @@ const storeSecurityEvents = async () => {
     }
     try {
       await elasticSearch.index({
-        index: `staart-events-${year}-${month}-${day}`,
+        index: `${ELASTIC_EVENTS_PREFIX}${year}-${month}-${day}`,
         body,
         type: "log"
       });
@@ -66,7 +67,7 @@ const storeTrackingLogs = async () => {
   for await (const body of data) {
     try {
       await elasticSearch.index({
-        index: `staart-logs-${year}-${month}-${day}`,
+        index: `${ELASTIC_LOGS_PREFIX}${year}-${month}-${day}`,
         body,
         type: "log"
       });

--- a/src/crud/billing.ts
+++ b/src/crud/billing.ts
@@ -28,7 +28,7 @@ export const getStripeCustomer = async (id: string) => {
  * Get the details of a customer
  */
 export const createStripeCustomer = async (
-  organizationId: number,
+  organizationId: string,
   customer: Stripe.customers.ICustomerCreationOptions
 ) => {
   const created = await stripe.customers.create({

--- a/src/crud/email.ts
+++ b/src/crud/email.ts
@@ -53,7 +53,7 @@ export const createEmail = async (
  * Send an email verification link
  */
 export const sendEmailVerification = async (
-  id: number,
+  id: string,
   email: string,
   user: User
 ) => {
@@ -65,7 +65,7 @@ export const sendEmailVerification = async (
 /**
  * Resend an email verification link
  */
-export const resendEmailVerification = async (id: number) => {
+export const resendEmailVerification = async (id: string) => {
   const token = await emailVerificationToken(id);
   const emailObject = await getEmail(id);
   const email = emailObject.email;
@@ -77,7 +77,7 @@ export const resendEmailVerification = async (id: number) => {
 /**
  * Update a user's email details
  */
-export const updateEmail = async (id: number, email: KeyValue) => {
+export const updateEmail = async (id: string, email: KeyValue) => {
   email.updatedAt = new Date();
   email = removeReadOnlyValues(email);
   return await query(
@@ -89,14 +89,14 @@ export const updateEmail = async (id: number, email: KeyValue) => {
 /**
  * Delete a user's email
  */
-export const deleteEmail = async (id: number) => {
+export const deleteEmail = async (id: string) => {
   return await query(`DELETE FROM ${tableName("emails")} WHERE id = ?`, [id]);
 };
 
 /**
  * Delete a user's email
  */
-export const deleteAllUserEmails = async (userId: number) => {
+export const deleteAllUserEmails = async (userId: string) => {
   const allEmails = await getUserEmails(userId);
   allEmails.forEach(email => {
     if (email.id && email.email) {
@@ -110,7 +110,7 @@ export const deleteAllUserEmails = async (userId: number) => {
 /**
  * Get details about a user's email
  */
-export const getEmail = async (id: number) => {
+export const getEmail = async (id: string) => {
   return (<Email[]>(
     await query(`SELECT * FROM ${tableName("emails")} WHERE id = ? LIMIT 1`, [
       id
@@ -121,9 +121,9 @@ export const getEmail = async (id: number) => {
 /**
  * Get a user's primary email's detailed object
  */
-export const getUserPrimaryEmailObject = async (user: User | number) => {
+export const getUserPrimaryEmailObject = async (user: User | string) => {
   let userObject: User;
-  if (typeof user === "number") {
+  if (typeof user === "string") {
     userObject = await getUser(user);
   } else {
     userObject = user;
@@ -138,14 +138,14 @@ export const getUserPrimaryEmailObject = async (user: User | number) => {
 /**
  * Get a user's primary email
  */
-export const getUserPrimaryEmail = async (user: User | number) => {
+export const getUserPrimaryEmail = async (user: User | string) => {
   return (await getUserPrimaryEmailObject(user)).email;
 };
 
 /**
  * Get a list of all emails added by a user
  */
-export const getUserEmails = async (userId: number) => {
+export const getUserEmails = async (userId: string) => {
   return await addIsPrimaryToEmails(<Email[]>(
     await query(`SELECT * FROM ${tableName("emails")} WHERE userId = ?`, [
       userId
@@ -156,7 +156,7 @@ export const getUserEmails = async (userId: number) => {
 /**
  * Gets the best email to get in touch with a user
  */
-export const getUserBestEmail = async (userId: number) => {
+export const getUserBestEmail = async (userId: string) => {
   try {
     return await getUserPrimaryEmail(userId);
   } catch (error) {}
@@ -201,11 +201,11 @@ export const getVerifiedEmailObject = async (email: string) => {
 /**
  * Get a list of all verified emails of a user
  */
-export const getUserVerifiedEmails = async (user: User | number) => {
+export const getUserVerifiedEmails = async (user: User | string) => {
   let userId = 0;
   if (typeof user === "object" && user.id) {
     userId = user.id;
-  } else if (typeof user === "number") {
+  } else if (typeof user === "string") {
     userId = user;
   }
   if (!userId) throw new Error(ErrorCode.USER_NOT_FOUND);

--- a/src/crud/email.ts
+++ b/src/crud/email.ts
@@ -202,7 +202,7 @@ export const getVerifiedEmailObject = async (email: string) => {
  * Get a list of all verified emails of a user
  */
 export const getUserVerifiedEmails = async (user: User | string) => {
-  let userId = 0;
+  let userId = "";
   if (typeof user === "object" && user.id) {
     userId = user.id;
   } else if (typeof user === "string") {

--- a/src/crud/membership.ts
+++ b/src/crud/membership.ts
@@ -31,7 +31,7 @@ export const createMembership = async (membership: Membership) => {
 /*
  * Update an organization membership for a user
  */
-export const updateMembership = async (id: number, membership: KeyValue) => {
+export const updateMembership = async (id: string, membership: KeyValue) => {
   membership.updatedAt = new Date();
   membership = removeReadOnlyValues(membership);
   const membershipDetails = await getMembership(id);
@@ -52,7 +52,7 @@ export const updateMembership = async (id: number, membership: KeyValue) => {
 /*
  * Delete an organization membership
  */
-export const deleteMembership = async (id: number) => {
+export const deleteMembership = async (id: string) => {
   const membershipDetails = await getMembership(id);
   if (membershipDetails.id)
     deleteItemFromCache(
@@ -68,7 +68,7 @@ export const deleteMembership = async (id: number) => {
 /*
  * Delete all memberships for a user
  */
-export const deleteAllUserMemberships = async (userId: number) => {
+export const deleteAllUserMemberships = async (userId: string) => {
   const allMemberships = await getUserMemberships(userId);
   for await (const membership of allMemberships) {
     if (membership.id) {
@@ -84,7 +84,7 @@ export const deleteAllUserMemberships = async (userId: number) => {
 /*
  * Get details about a specific organization membership
  */
-export const getMembership = async (id: number) => {
+export const getMembership = async (id: string) => {
   return (<Membership[]>(
     await cachedQuery(
       CacheCategories.MEMBERSHIP,
@@ -98,7 +98,7 @@ export const getMembership = async (id: number) => {
 /*
  * Get a detailed version of a membership
  */
-export const getMembershipDetailed = async (id: number) => {
+export const getMembershipDetailed = async (id: string) => {
   const membership = (await getMembership(id)) as any;
   if (!membership || !membership.id)
     throw new Error(ErrorCode.MEMBERSHIP_NOT_FOUND);
@@ -110,7 +110,7 @@ export const getMembershipDetailed = async (id: number) => {
 /*
  * Get a list of all members in an organization
  */
-export const getOrganizationMembers = async (organizationId: number) => {
+export const getOrganizationMembers = async (organizationId: string) => {
   return <Membership[]>(
     await query(
       `SELECT * FROM ${tableName("memberships")} WHERE organizationId = ?`,
@@ -119,8 +119,8 @@ export const getOrganizationMembers = async (organizationId: number) => {
   );
 };
 
-export const getUserMemberships = async (user: User | number) => {
-  if (typeof user !== "number" && typeof user !== "string") {
+export const getUserMemberships = async (user: User | string) => {
+  if (typeof user !== "string" && typeof user !== "string") {
     if (user.id) user = user.id;
     else throw new Error(ErrorCode.USER_NOT_FOUND);
   }
@@ -161,7 +161,7 @@ export const addOrganizationToMemberships = async (
 /**
  * Get a detailed object of a user's membership
  */
-export const getUserMembershipsDetailed = async (user: User | number) => {
+export const getUserMembershipsDetailed = async (user: User | string) => {
   const memberships: any = await getUserMemberships(user);
   for await (const membership of memberships) {
     membership.organization = await getOrganization(membership.organizationId);
@@ -173,14 +173,14 @@ export const getUserMembershipsDetailed = async (user: User | number) => {
  * Get a user membership of a particular organization
  */
 export const getUserOrganizationMembership = async (
-  user: User | number,
-  organization: Organization | number
+  user: User | string,
+  organization: Organization | string
 ) => {
-  if (typeof user !== "number" && typeof user !== "string") {
+  if (typeof user !== "string" && typeof user !== "string") {
     if (user.id) user = user.id;
     else throw new Error(ErrorCode.USER_NOT_FOUND);
   }
-  if (typeof organization !== "number" && typeof organization !== "string") {
+  if (typeof organization !== "string" && typeof organization !== "string") {
     if (organization.id) organization = organization.id;
     else throw new Error(ErrorCode.ORGANIZATION_NOT_FOUND);
   }

--- a/src/crud/organization.ts
+++ b/src/crud/organization.ts
@@ -58,7 +58,7 @@ export const createOrganization = async (organization: Organization) => {
 /*
  * Get the details of a specific organization
  */
-export const getOrganization = async (id: number) => {
+export const getOrganization = async (id: string) => {
   const org = (<Organization[]>(
     await cachedQuery(
       CacheCategories.ORGANIZATION,
@@ -91,7 +91,7 @@ export const getOrganizationIdFromUsername = async (username: string) => {
  * Update an organization
  */
 export const updateOrganization = async (
-  id: number,
+  id: string,
   organization: KeyValue
 ) => {
   organization.updatedAt = new Date();
@@ -123,7 +123,7 @@ export const updateOrganization = async (
 /*
  * Delete an organization
  */
-export const deleteOrganization = async (id: number) => {
+export const deleteOrganization = async (id: string) => {
   deleteItemFromCache(CacheCategories.ORGANIZATION, id);
   return await query(`DELETE FROM ${tableName("organizations")} WHERE id = ?`, [
     id
@@ -143,7 +143,7 @@ export const getAllOrganizations = async () => {
  * Get a list of all approved locations of a user
  */
 export const getOrganizationApiKeys = async (
-  organizationId: number,
+  organizationId: string,
   query: KeyValue
 ) => {
   return await getPaginatedData({
@@ -158,7 +158,7 @@ export const getOrganizationApiKeys = async (
 /**
  * Get an API key
  */
-export const getApiKey = async (organizationId: number, apiKeyId: number) => {
+export const getApiKey = async (organizationId: string, apiKeyId: string) => {
   return (<ApiKey[]>(
     await query(
       `SELECT * FROM ${tableName(
@@ -173,8 +173,8 @@ export const getApiKey = async (organizationId: number, apiKeyId: number) => {
  * Get an API key
  */
 export const getApiKeyLogs = async (
-  organizationId: number,
-  apiKeyId: number,
+  organizationId: string,
+  apiKeyId: string,
   query: KeyValue
 ) => {
   await getApiKey(organizationId, apiKeyId);
@@ -231,8 +231,8 @@ export const createApiKey = async (apiKey: ApiKey) => {
  * Update a user's details
  */
 export const updateApiKey = async (
-  organizationId: number,
-  apiKeyId: number,
+  organizationId: string,
+  apiKeyId: string,
   data: KeyValue
 ) => {
   data.updatedAt = new Date();
@@ -252,8 +252,8 @@ export const updateApiKey = async (
  * Delete an API key
  */
 export const deleteApiKey = async (
-  organizationId: number,
-  apiKeyId: number
+  organizationId: string,
+  apiKeyId: string
 ) => {
   const currentApiKey = await getApiKey(organizationId, apiKeyId);
   if (currentApiKey.jwtApiKey) await invalidateToken(currentApiKey.jwtApiKey);
@@ -269,7 +269,7 @@ export const deleteApiKey = async (
  * Get a list of domains for an organization
  */
 export const getOrganizationDomains = async (
-  organizationId: number,
+  organizationId: string,
   query: KeyValue
 ) => {
   return await getPaginatedData({
@@ -284,7 +284,7 @@ export const getOrganizationDomains = async (
 /**
  * Get a domain
  */
-export const getDomain = async (organizationId: number, domainId: number) => {
+export const getDomain = async (organizationId: string, domainId: string) => {
   return (<Domain[]>(
     await query(
       `SELECT * FROM ${tableName(
@@ -310,7 +310,7 @@ export const getDomainByDomainName = async (domain: string) => {
 };
 
 export const updateOrganizationProfilePicture = async (
-  organizationId: number
+  organizationId: string
 ) => {
   const domains = await getOrganizationDomains(organizationId, {});
   if (domains && domains.data && domains.data.length) {
@@ -362,8 +362,8 @@ export const createDomain = async (domain: Domain): Promise<InsertResult> => {
  * Update a domain
  */
 export const updateDomain = async (
-  organizationId: number,
-  domainId: number,
+  organizationId: string,
+  domainId: string,
   data: KeyValue
 ) => {
   data.updatedAt = new Date();
@@ -381,8 +381,8 @@ export const updateDomain = async (
  * Delete a domain
  */
 export const deleteDomain = async (
-  organizationId: number,
-  domainId: number
+  organizationId: string,
+  domainId: string
 ) => {
   const currentDomain = await getDomain(organizationId, domainId);
   const response = await query(
@@ -410,7 +410,7 @@ export const checkDomainAvailability = async (username: string) => {
  * Get a list of webhooks for an organization
  */
 export const getOrganizationWebhooks = async (
-  organizationId: number,
+  organizationId: string,
   query: KeyValue
 ) => {
   return await getPaginatedData({
@@ -426,7 +426,7 @@ export const getOrganizationWebhooks = async (
  * Get a webhook
  */
 export const getOrganizationEventWebhooks = async (
-  organizationId: number,
+  organizationId: string,
   event: Webhooks
 ) => {
   return <Webhook[]>(
@@ -442,7 +442,7 @@ export const getOrganizationEventWebhooks = async (
 /**
  * Get a webhook
  */
-export const getWebhook = async (organizationId: number, webhookId: number) => {
+export const getWebhook = async (organizationId: string, webhookId: string) => {
   return (<Webhook[]>(
     await query(
       `SELECT * FROM ${tableName(
@@ -473,8 +473,8 @@ export const createWebhook = async (
  * Update a webhook
  */
 export const updateWebhook = async (
-  organizationId: number,
-  webhookId: number,
+  organizationId: string,
+  webhookId: string,
   data: KeyValue
 ) => {
   data.updatedAt = new Date();
@@ -492,8 +492,8 @@ export const updateWebhook = async (
  * Delete a webhook
  */
 export const deleteWebhook = async (
-  organizationId: number,
-  webhookId: number
+  organizationId: string,
+  webhookId: string
 ) => {
   const currentWebhook = await getWebhook(organizationId, webhookId);
   return await query(
@@ -508,7 +508,7 @@ export const deleteWebhook = async (
  * Get a detailed list of all members in an organization
  */
 export const getOrganizationMemberships = async (
-  organizationId: number,
+  organizationId: string,
   query?: KeyValue
 ) => {
   const members: any = await getPaginatedData({
@@ -526,8 +526,8 @@ export const getOrganizationMemberships = async (
  * Get details about a specific organization membership
  */
 export const getOrganizationMembership = async (
-  organizationId: number,
-  id: number
+  organizationId: string,
+  id: string
 ) => {
   return (<Membership[]>(
     await cachedQuery(
@@ -545,8 +545,8 @@ export const getOrganizationMembership = async (
  * Get a detailed version of a membership
  */
 export const getOrganizationMembershipDetailed = async (
-  organizationId: number,
-  id: number
+  organizationId: string,
+  id: string
 ) => {
   const membership = (await getOrganizationMembership(
     organizationId,
@@ -563,8 +563,8 @@ export const getOrganizationMembershipDetailed = async (
  * Update an organization membership for a user
  */
 export const updateOrganizationMembership = async (
-  organizationId: number,
-  id: number,
+  organizationId: string,
+  id: string,
   membership: KeyValue
 ) => {
   membership.updatedAt = new Date();
@@ -588,8 +588,8 @@ export const updateOrganizationMembership = async (
  * Delete an organization membership
  */
 export const deleteOrganizationMembership = async (
-  organizationId: number,
-  id: number
+  organizationId: string,
+  id: string
 ) => {
   const membershipDetails = await getOrganizationMembership(organizationId, id);
   if (membershipDetails.id)
@@ -610,7 +610,7 @@ export const deleteOrganizationMembership = async (
  * Delete all memberships in an organization
  */
 export const deleteAllOrganizationMemberships = async (
-  organizationId: number
+  organizationId: string
 ) => {
   const allMemberships = await getOrganizationMemberships(organizationId);
   for await (const membership of allMemberships.data) {

--- a/src/crud/organization.ts
+++ b/src/crud/organization.ts
@@ -19,7 +19,11 @@ import { ApiKey } from "../interfaces/tables/organization";
 import { getPaginatedData } from "./data";
 import cryptoRandomString from "crypto-random-string";
 import { apiKeyToken, invalidateToken } from "../helpers/jwt";
-import { TOKEN_EXPIRY_API_KEY_MAX, JWT_ISSUER } from "../config";
+import {
+  TOKEN_EXPIRY_API_KEY_MAX,
+  JWT_ISSUER,
+  ELASTIC_LOGS_PREFIX
+} from "../config";
 import { InsertResult } from "../interfaces/mysql";
 import { Membership } from "../interfaces/tables/memberships";
 import { getUser } from "./user";
@@ -181,7 +185,7 @@ export const getApiKeyLogs = async (
   const range: string = query.range || "7d";
   const from = query.from ? parseInt(query.from) : 0;
   const result = await elasticSearch.search({
-    index: `staart-logs-*`,
+    index: `${ELASTIC_LOGS_PREFIX}*`,
     from,
     body: {
       query: {

--- a/src/crud/user.ts
+++ b/src/crud/user.ts
@@ -261,7 +261,7 @@ export const createBackupCodes = async (userId: string, count = 1) => {
     code.createdAt = new Date();
     code.updatedAt = code.createdAt;
     await query(
-      `INSERT INTO \`backup-codes\` ${tableValues(code)}`,
+      `INSERT INTO ${tableName("backup-codes")} ${tableValues(code)}`,
       Object.values(code)
     );
   }
@@ -274,7 +274,7 @@ export const createBackupCodes = async (userId: string, count = 1) => {
 export const updateBackupCode = async (backupCode: number, code: KeyValue) => {
   code.updatedAt = new Date();
   return await query(
-    `UPDATE \`backup-codes\` SET ${setValues(code)} WHERE code = ?`,
+    `UPDATE ${tableName("backup-codes")} SET ${setValues(code)} WHERE code = ?`,
     [...Object.values(code), backupCode]
   );
 };
@@ -283,21 +283,30 @@ export const updateBackupCode = async (backupCode: number, code: KeyValue) => {
  * Delete a backup code
  */
 export const deleteBackupCode = async (backupCode: number) => {
-  return await query("DELETE FROM `backup-codes` WHERE code = ?", [backupCode]);
+  return await query(
+    `DELETE FROM ${tableName("backup-codes")} WHERE code = ?`,
+    [backupCode]
+  );
 };
 
 /**
  * Delete all backup codes of a user
  */
 export const deleteUserBackupCodes = async (userId: string) => {
-  return await query("DELETE FROM `backup-codes` WHERE userId = ?", [userId]);
+  return await query(
+    `DELETE FROM ${tableName("backup-codes")} WHERE userId = ?`,
+    [userId]
+  );
 };
 
 /**
  * Get all backup codes of a user
  */
 export const getUserBackupCodes = async (userId: string) => {
-  return await query("SELECT * FROM `backup-codes` WHERE userId = ?", [userId]);
+  return await query(
+    `SELECT * FROM ${tableName("backup-codes")} WHERE userId = ?`,
+    [userId]
+  );
 };
 
 /**
@@ -306,7 +315,9 @@ export const getUserBackupCodes = async (userId: string) => {
 export const getUserBackupCode = async (userId: string, backupCode: number) => {
   return (<BackupCode[]>(
     await query(
-      "SELECT * FROM `backup-codes` WHERE userId = ? AND code = ? LIMIT 1",
+      `SELECT * FROM ${tableName(
+        "backup-codes"
+      )} WHERE userId = ? AND code = ? LIMIT 1`,
       [userId, backupCode]
     )
   ))[0];

--- a/src/crud/user.ts
+++ b/src/crud/user.ts
@@ -75,7 +75,7 @@ export const createUser = async (user: User) => {
  * Get the details of a user
  * @param secureOrigin  Whether security keys (password/tokens) should be returned too
  */
-export const getUser = async (id: number, secureOrigin = false) => {
+export const getUser = async (id: string, secureOrigin = false) => {
   let user = (<User[]>(
     await cachedQuery(
       CacheCategories.USER,
@@ -118,7 +118,7 @@ export const getUserIdFromUsername = async (username: string) => {
 /**
  * Update a user's details
  */
-export const updateUser = async (id: number, user: KeyValue) => {
+export const updateUser = async (id: string, user: KeyValue) => {
   user.updatedAt = new Date();
   if (user.password) user.password = await hash(user.password, 8);
   user = removeReadOnlyValues(user);
@@ -160,7 +160,7 @@ export const updateUser = async (id: number, user: KeyValue) => {
 /**
  * Delete a user
  */
-export const deleteUser = async (id: number) => {
+export const deleteUser = async (id: string) => {
   deleteItemFromCache(CacheCategories.USER, id);
   return await query(`DELETE FROM ${tableName("users")} WHERE id = ?`, [id]);
 };
@@ -170,7 +170,7 @@ export const deleteUser = async (id: number) => {
  * @param ipAddress  IP address for the new location
  */
 export const addApprovedLocation = async (
-  userId: number,
+  userId: string,
   ipAddress: string
 ) => {
   const subnet = anonymizeIpAddress(ipAddress);
@@ -190,7 +190,7 @@ export const addApprovedLocation = async (
 /**
  * Get a list of all approved locations of a user
  */
-export const getUserApprovedLocations = async (userId: number) => {
+export const getUserApprovedLocations = async (userId: string) => {
   return await query(
     `SELECT * FROM ${tableName("approved-locations")} WHERE userId = ?`,
     [userId]
@@ -221,7 +221,7 @@ export const checkUsernameAvailability = async (username: string) => {
 /**
  * Delete all approved locations for a user
  */
-export const deleteAllUserApprovedLocations = async (userId: number) => {
+export const deleteAllUserApprovedLocations = async (userId: string) => {
   return await query(
     `DELETE FROM ${tableName("approved-locations")} WHERE userId = ?`,
     [userId]
@@ -233,7 +233,7 @@ export const deleteAllUserApprovedLocations = async (userId: number) => {
  * @param ipAddress  IP address for checking
  */
 export const checkApprovedLocation = async (
-  userId: number,
+  userId: string,
   ipAddress: string
 ) => {
   const user = await getUser(userId);
@@ -255,7 +255,7 @@ export const checkApprovedLocation = async (
  * Create 2FA backup codes for user
  * @param count - Number of backup codes to create
  */
-export const createBackupCodes = async (userId: number, count = 1) => {
+export const createBackupCodes = async (userId: string, count = 1) => {
   for await (const x of Array.from(Array(count).keys())) {
     const code: BackupCode = { code: randomInt(100000, 999999), userId };
     code.createdAt = new Date();
@@ -271,7 +271,7 @@ export const createBackupCodes = async (userId: number, count = 1) => {
 /**
  * Update a backup code
  */
-export const updateBackupCode = async (backupCode: number, code: KeyValue) => {
+export const updateBackupCode = async (backupCode: string, code: KeyValue) => {
   code.updatedAt = new Date();
   return await query(
     `UPDATE \`backup-codes\` SET ${setValues(code)} WHERE code = ?`,
@@ -282,28 +282,28 @@ export const updateBackupCode = async (backupCode: number, code: KeyValue) => {
 /**
  * Delete a backup code
  */
-export const deleteBackupCode = async (backupCode: number) => {
+export const deleteBackupCode = async (backupCode: string) => {
   return await query("DELETE FROM `backup-codes` WHERE code = ?", [backupCode]);
 };
 
 /**
  * Delete all backup codes of a user
  */
-export const deleteUserBackupCodes = async (userId: number) => {
+export const deleteUserBackupCodes = async (userId: string) => {
   return await query("DELETE FROM `backup-codes` WHERE userId = ?", [userId]);
 };
 
 /**
  * Get all backup codes of a user
  */
-export const getUserBackupCodes = async (userId: number) => {
+export const getUserBackupCodes = async (userId: string) => {
   return await query("SELECT * FROM `backup-codes` WHERE userId = ?", [userId]);
 };
 
 /**
  * Get a specific backup code
  */
-export const getUserBackupCode = async (userId: number, backupCode: number) => {
+export const getUserBackupCode = async (userId: string, backupCode: string) => {
   return (<BackupCode[]>(
     await query(
       "SELECT * FROM `backup-codes` WHERE userId = ? AND code = ? LIMIT 1",
@@ -315,7 +315,7 @@ export const getUserBackupCode = async (userId: number, backupCode: number) => {
 /**
  * Get a list of all approved locations of a user
  */
-export const getUserAccessTokens = async (userId: number, query: KeyValue) => {
+export const getUserAccessTokens = async (userId: string, query: KeyValue) => {
   return await getPaginatedData({
     table: "access-tokens",
     conditions: {
@@ -328,7 +328,7 @@ export const getUserAccessTokens = async (userId: number, query: KeyValue) => {
 /**
  * Get an API key
  */
-export const getAccessToken = async (userId: number, accessTokenId: number) => {
+export const getAccessToken = async (userId: string, accessTokenId: string) => {
   return (<AccessToken[]>(
     await query(
       `SELECT * FROM ${tableName(
@@ -358,8 +358,8 @@ export const createAccessToken = async (newAccessToken: AccessToken) => {
  * Update a user's details
  */
 export const updateAccessToken = async (
-  userId: number,
-  accessTokenId: number,
+  userId: string,
+  accessTokenId: string,
   data: KeyValue
 ) => {
   data.updatedAt = new Date();
@@ -380,8 +380,8 @@ export const updateAccessToken = async (
  * Delete an API key
  */
 export const deleteAccessToken = async (
-  userId: number,
-  accessTokenId: number
+  userId: string,
+  accessTokenId: string
 ) => {
   const currentAccessToken = await getAccessToken(userId, accessTokenId);
   if (currentAccessToken.jwtAccessToken)
@@ -397,7 +397,7 @@ export const deleteAccessToken = async (
 /**
  * Get a list of all valid sessions of a user
  */
-export const getUserSessions = async (userId: number, query: KeyValue) => {
+export const getUserSessions = async (userId: string, query: KeyValue) => {
   const data = await getPaginatedData({
     table: "sessions",
     conditions: {
@@ -416,7 +416,7 @@ export const getUserSessions = async (userId: number, query: KeyValue) => {
 /**
  * Get a session
  */
-export const getSession = async (userId: number, sessionId: number) => {
+export const getSession = async (userId: string, sessionId: string) => {
   const data = await addLocationToSession(
     (<Session[]>(
       await query(
@@ -447,8 +447,8 @@ export const createSession = async (newSession: Session) => {
  * Update a user's details
  */
 export const updateSession = async (
-  userId: number,
-  sessionId: number,
+  userId: string,
+  sessionId: string,
   data: KeyValue
 ) => {
   data.updatedAt = new Date();
@@ -465,7 +465,7 @@ export const updateSession = async (
  * Update a user's details
  */
 export const updateSessionByJwt = async (
-  userId: number,
+  userId: string,
   sessionJwt: string,
   data: KeyValue
 ) => {
@@ -482,7 +482,7 @@ export const updateSessionByJwt = async (
 /**
  * Invalidate a session
  */
-export const deleteSession = async (userId: number, sessionId: number) => {
+export const deleteSession = async (userId: string, sessionId: string) => {
   const currentSession = await getSession(userId, sessionId);
   if (currentSession.jwtToken) await invalidateToken(currentSession.jwtToken);
   return await query(

--- a/src/crud/user.ts
+++ b/src/crud/user.ts
@@ -271,7 +271,7 @@ export const createBackupCodes = async (userId: string, count = 1) => {
 /**
  * Update a backup code
  */
-export const updateBackupCode = async (backupCode: string, code: KeyValue) => {
+export const updateBackupCode = async (backupCode: number, code: KeyValue) => {
   code.updatedAt = new Date();
   return await query(
     `UPDATE \`backup-codes\` SET ${setValues(code)} WHERE code = ?`,
@@ -282,7 +282,7 @@ export const updateBackupCode = async (backupCode: string, code: KeyValue) => {
 /**
  * Delete a backup code
  */
-export const deleteBackupCode = async (backupCode: string) => {
+export const deleteBackupCode = async (backupCode: number) => {
   return await query("DELETE FROM `backup-codes` WHERE code = ?", [backupCode]);
 };
 
@@ -303,7 +303,7 @@ export const getUserBackupCodes = async (userId: string) => {
 /**
  * Get a specific backup code
  */
-export const getUserBackupCode = async (userId: string, backupCode: string) => {
+export const getUserBackupCode = async (userId: string, backupCode: number) => {
   return (<BackupCode[]>(
     await query(
       "SELECT * FROM `backup-codes` WHERE userId = ? AND code = ? LIMIT 1",

--- a/src/helpers/__tests__/utils.ts
+++ b/src/helpers/__tests__/utils.ts
@@ -29,7 +29,7 @@ test("Convert date to MySQL datetime", () => {
 test("Remove sensitive info", () => {
   expect(
     deleteSensitiveInfoUser({
-      id: 1,
+      id: "wiuhoeijpaoe",
       name: "Anand Chowdhary",
       password: "1abc9c"
     }).password

--- a/src/helpers/authorization.ts
+++ b/src/helpers/authorization.ts
@@ -231,10 +231,10 @@ const canApiKeyOrganization = (
  * Whether a user has authorization to perform an action
  */
 export const can = async (
-  user: User | number | ApiKeyResponse | AccessTokenResponse,
+  user: User | string | ApiKeyResponse | AccessTokenResponse,
   action: Authorizations | OrgScopes | UserScopes,
   targetType: "user" | "organization" | "membership" | "general",
-  target?: User | Organization | Membership | number
+  target?: User | Organization | Membership | string
 ) => {
   let userObject: User | ApiKeyResponse | undefined = undefined;
   let isApiKey = false;
@@ -249,7 +249,7 @@ export const can = async (
       userObject = user as User;
     }
   } else {
-    userObject = await getUser(user as number);
+    userObject = await getUser(user as string);
   }
 
   if (isApiKey) {
@@ -292,7 +292,7 @@ export const can = async (
 
   let targetObject: User | Organization | Membership;
   if (targetType === "user") {
-    if (typeof target === "string" || typeof target === "number")
+    if (typeof target === "string" || typeof target === "string")
       targetObject = await getUser(target);
     else targetObject = target as User;
     return await canUserUser(
@@ -301,7 +301,7 @@ export const can = async (
       targetObject as User
     );
   } else if (targetType === "organization") {
-    if (typeof target === "string" || typeof target === "number")
+    if (typeof target === "string" || typeof target === "string")
       targetObject = await getOrganization(target);
     else targetObject = target as Organization;
     return await canUserOrganization(
@@ -310,7 +310,7 @@ export const can = async (
       targetObject as Organization
     );
   } else if (targetType === "membership") {
-    if (typeof target === "string" || typeof target === "number")
+    if (typeof target === "string" || typeof target === "string")
       targetObject = await getMembership(target);
     else targetObject = target as Membership;
     return await canUserMembership(

--- a/src/helpers/jwt.ts
+++ b/src/helpers/jwt.ts
@@ -66,12 +66,12 @@ export const generateToken = (
  * Verify a JWT
  */
 export interface TokenResponse {
-  id: number;
+  id: string;
   ipAddress?: string;
 }
 export interface ApiKeyResponse {
-  id: number;
-  organizationId: number;
+  id: string;
+  organizationId: string;
   scopes: string;
   jti: string;
   sub: Tokens;
@@ -93,13 +93,13 @@ export const verifyToken = (
 /**
  * Generate a new email verification JWT
  */
-export const emailVerificationToken = (id: number) =>
+export const emailVerificationToken = (id: string) =>
   generateToken({ id }, TOKEN_EXPIRY_EMAIL_VERIFICATION, Tokens.EMAIL_VERIFY);
 
 /**
  * Generate a new password reset JWT
  */
-export const passwordResetToken = (id: number) =>
+export const passwordResetToken = (id: string) =>
   generateToken({ id }, TOKEN_EXPIRY_PASSWORD_RESET, Tokens.PASSWORD_RESET);
 
 /**
@@ -156,7 +156,7 @@ export const accessToken = (accessToken: AccessToken) => {
 /**
  * Generate a new approve location JWT
  */
-export const approveLocationToken = (id: number, ipAddress: string) =>
+export const approveLocationToken = (id: string, ipAddress: string) =>
   generateToken(
     { id, ipAddress },
     TOKEN_EXPIRY_APPROVE_LOCATION,
@@ -166,7 +166,7 @@ export const approveLocationToken = (id: number, ipAddress: string) =>
 /**
  * Generate a new refresh JWT
  */
-export const refreshToken = (id: number) =>
+export const refreshToken = (id: string) =>
   generateToken({ id }, TOKEN_EXPIRY_REFRESH, Tokens.REFRESH);
 
 export const postLoginTokens = async (

--- a/src/helpers/mysql.ts
+++ b/src/helpers/mysql.ts
@@ -5,7 +5,8 @@ import {
   DB_PORT,
   DB_PASSWORD,
   DB_DATABASE,
-  DB_TABLE_PREFIX
+  DB_TABLE_PREFIX,
+  HASH_ID_PREFIX
 } from "../config";
 import { User, BackupCode } from "../interfaces/tables/user";
 import { Email } from "../interfaces/tables/emails";
@@ -112,7 +113,7 @@ export const cleanValues = (
     // Clean up strings
     if (typeof value === "string") {
       value = unemojify(value.trim());
-      if (value.startsWith("hashid-")) {
+      if (value.startsWith(HASH_ID_PREFIX)) {
         value = hashIdToId(value);
       }
     }

--- a/src/helpers/mysql.ts
+++ b/src/helpers/mysql.ts
@@ -44,7 +44,6 @@ export const query = (
     pool.getConnection((error, connection) => {
       if (error) return reject(error);
       if (values) values = cleanValues(values);
-      console.log("QUERY", queryString, values);
       connection.query(queryString, values, (error, result) => {
         connection.destroy();
         if (error) return reject(error);

--- a/src/helpers/mysql.ts
+++ b/src/helpers/mysql.ts
@@ -12,7 +12,14 @@ import { Email } from "../interfaces/tables/emails";
 import { Membership } from "../interfaces/tables/memberships";
 import { Organization } from "../interfaces/tables/organization";
 import { KeyValue } from "../interfaces/general";
-import { boolValues, jsonValues, dateValues, readOnlyValues } from "./utils";
+import {
+  boolValues,
+  jsonValues,
+  dateValues,
+  readOnlyValues,
+  generateHashId,
+  hashIdToId
+} from "./utils";
 import { getUserPrimaryEmailObject } from "../crud/email";
 import { InsertResult } from "../interfaces/mysql";
 import { emojify, unemojify } from "node-emoji";
@@ -36,6 +43,7 @@ export const query = (
     pool.getConnection((error, connection) => {
       if (error) return reject(error);
       if (values) values = cleanValues(values);
+      console.log("QUERY", queryString, values);
       connection.query(queryString, values, (error, result) => {
         connection.destroy();
         if (error) return reject(error);
@@ -85,6 +93,7 @@ export const uncleanValues = (
             )
           ).toISOString();
         }
+        if (key === "id") item[key] = generateHashId(item[key]);
         if (typeof item[key] === "string") item[key] = emojify(item[key]);
       });
       return item;
@@ -103,6 +112,9 @@ export const cleanValues = (
     // Clean up strings
     if (typeof value === "string") {
       value = unemojify(value.trim());
+      if (value.startsWith("hashid-")) {
+        value = hashIdToId(value);
+      }
     }
     // Convert true to 1, false to 0
     if (typeof value === "boolean") value = value ? 1 : 0;

--- a/src/helpers/mysql.ts
+++ b/src/helpers/mysql.ts
@@ -18,7 +18,8 @@ import {
   dateValues,
   readOnlyValues,
   generateHashId,
-  hashIdToId
+  hashIdToId,
+  IdValues
 } from "./utils";
 import { getUserPrimaryEmailObject } from "../crud/email";
 import { InsertResult } from "../interfaces/mysql";
@@ -93,7 +94,7 @@ export const uncleanValues = (
             )
           ).toISOString();
         }
-        if (key === "id") item[key] = generateHashId(item[key]);
+        if (IdValues.includes(key)) item[key] = generateHashId(item[key]);
         if (typeof item[key] === "string") item[key] = emojify(item[key]);
       });
       return item;

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -179,7 +179,7 @@ export const readOnlyValues = [
 /**
  * MySQL columns which are for int IDs
  */
-export const IdValues = ["id", "userId", "organizationId", "primaryEmailId"];
+export const IdValues = ["id", "userId", "organizationId", "primaryEmail"];
 
 export const joiValidate = (schemaMap: Joi.SchemaMap, data: any) => {
   const schema = Joi.object().keys(schemaMap);

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -11,7 +11,7 @@ import { ApiKeyResponse } from "./jwt";
 import { isMatch } from "matcher";
 import Hashids from "hashids/cjs";
 import { getUserIdFromUsername } from "../crud/user";
-import { HASH_IDS } from "../config";
+import { HASH_IDS, HASH_ID_PREFIX } from "../config";
 
 const hashIds = new Hashids(
   HASH_IDS,
@@ -87,13 +87,14 @@ export const userUsernameToId = async (id: string, tokenUserId: string) => {
   }
 };
 
-export const generateHashId = (id: string) => `hashid-${hashIds.encode(id)}`;
+export const generateHashId = (id: string) =>
+  `${HASH_ID_PREFIX}${hashIds.encode(id)}`;
 
 export const hashIdToId = (id: string | number): string => {
   if (typeof id === "number") return id.toString();
-  if (id.startsWith("hashid-")) {
+  if (id.startsWith(HASH_ID_PREFIX)) {
     const numberId = parseInt(
-      hashIds.decode(id.replace("hashid-", "")).join("")
+      hashIds.decode(id.replace(HASH_ID_PREFIX, "")).join("")
     );
     if (isNaN(numberId)) {
       const newId = parseInt(id);

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -9,7 +9,15 @@ import cryptoRandomString from "crypto-random-string";
 import { Tokens } from "../interfaces/enum";
 import { ApiKeyResponse } from "./jwt";
 import { isMatch } from "matcher";
+import Hashids from "hashids";
 import { getUserIdFromUsername } from "../crud/user";
+import { HASH_IDS } from "../config";
+
+const hashIds = new Hashids(
+  HASH_IDS,
+  10,
+  "abcdefghijklmnopqrstuvwxyz1234567890"
+);
 
 /**
  * Capitalize each first letter in a string
@@ -77,6 +85,21 @@ export const userUsernameToId = async (id: string, tokenUserId: number) => {
   } else {
     return parseInt(id);
   }
+};
+
+export const generateHashId = (id: number) => hashIds.encode(id);
+
+export const hashIdToId = (id: string | number) => {
+  if (typeof id === "number") return id;
+  if (id.startsWith("h")) {
+    const numberId = parseInt(hashIds.decode(id).join(""));
+    if (isNaN(numberId)) {
+      return parseInt(id);
+    } else {
+      return numberId;
+    }
+  }
+  return parseInt(id);
 };
 
 export const localsToTokenOrKey = (res: Response) => {

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -89,8 +89,8 @@ export const userUsernameToId = async (id: string, tokenUserId: string) => {
 
 export const generateHashId = (id: string) => `hashid-${hashIds.encode(id)}`;
 
-export const hashIdToId = (id: string | number) => {
-  if (typeof id === "number") return id;
+export const hashIdToId = (id: string | number): string => {
+  if (typeof id === "number") return id.toString();
   if (id.startsWith("hashid-")) {
     const numberId = parseInt(
       hashIds.decode(id.replace("hashid-", "")).join("")
@@ -100,10 +100,10 @@ export const hashIdToId = (id: string | number) => {
       if (isNaN(newId)) {
         return id;
       } else {
-        return newId;
+        return newId.toString();
       }
     } else {
-      return numberId;
+      return numberId.toString();
     }
   }
   return id;
@@ -113,7 +113,7 @@ export const localsToTokenOrKey = (res: Response) => {
   if (res.locals.token.sub == Tokens.API_KEY) {
     return res.locals.token as ApiKeyResponse;
   }
-  return res.locals.token.id as number;
+  return res.locals.token.id as string;
 };
 
 export const createSlug = (name: string) =>
@@ -175,6 +175,11 @@ export const readOnlyValues = [
   "userId",
   "organizationId"
 ];
+
+/**
+ * MySQL columns which are for int IDs
+ */
+export const IdValues = ["id", "userId", "organizationId", "primaryEmailId"];
 
 export const joiValidate = (schemaMap: Joi.SchemaMap, data: any) => {
   const schema = Joi.object().keys(schemaMap);

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -9,7 +9,7 @@ import cryptoRandomString from "crypto-random-string";
 import { Tokens } from "../interfaces/enum";
 import { ApiKeyResponse } from "./jwt";
 import { isMatch } from "matcher";
-import Hashids from "hashids";
+import Hashids from "hashids/cjs";
 import { getUserIdFromUsername } from "../crud/user";
 import { HASH_IDS } from "../config";
 
@@ -73,33 +73,40 @@ export const organizationUsernameToId = async (id: string) => {
   if (isNaN(Number(id))) {
     return await getOrganizationIdFromUsername(id);
   } else {
-    return parseInt(id);
+    return hashIdToId(id);
   }
 };
 
-export const userUsernameToId = async (id: string, tokenUserId: number) => {
+export const userUsernameToId = async (id: string, tokenUserId: string) => {
   if (id === "me") {
     return tokenUserId;
   } else if (isNaN(Number(id))) {
     return await getUserIdFromUsername(id);
   } else {
-    return parseInt(id);
+    return hashIdToId(id);
   }
 };
 
-export const generateHashId = (id: number) => hashIds.encode(id);
+export const generateHashId = (id: string) => `hashid-${hashIds.encode(id)}`;
 
 export const hashIdToId = (id: string | number) => {
   if (typeof id === "number") return id;
-  if (id.startsWith("h")) {
-    const numberId = parseInt(hashIds.decode(id).join(""));
+  if (id.startsWith("hashid-")) {
+    const numberId = parseInt(
+      hashIds.decode(id.replace("hashid-", "")).join("")
+    );
     if (isNaN(numberId)) {
-      return parseInt(id);
+      const newId = parseInt(id);
+      if (isNaN(newId)) {
+        return id;
+      } else {
+        return newId;
+      }
     } else {
       return numberId;
     }
   }
-  return parseInt(id);
+  return id;
 };
 
 export const localsToTokenOrKey = (res: Response) => {

--- a/src/helpers/webhooks.ts
+++ b/src/helpers/webhooks.ts
@@ -9,7 +9,7 @@ import axios from "axios";
 import { JWT_ISSUER } from "../config";
 
 export const queueWebhook = (
-  organizationId: number,
+  organizationId: string,
   webhook: Webhooks,
   data?: any
 ) => {
@@ -19,7 +19,7 @@ export const queueWebhook = (
 };
 
 export const safeFireWebhook = async (
-  organizationId: number,
+  organizationId: string,
   webhook: Webhooks,
   data?: any
 ) => {

--- a/src/interfaces/general.ts
+++ b/src/interfaces/general.ts
@@ -20,5 +20,5 @@ export interface Row {
 }
 
 export interface IdRow extends Row {
-  id?: number;
+  id?: string;
 }

--- a/src/interfaces/mysql.ts
+++ b/src/interfaces/mysql.ts
@@ -1,7 +1,7 @@
 export interface InsertResult {
   fieldCount: number;
   affectedRows: number;
-  insertId: number;
+  insertId: string;
   serverStatus: number;
   warningCount: number;
   message: string;

--- a/src/interfaces/tables/emails.ts
+++ b/src/interfaces/tables/emails.ts
@@ -1,7 +1,7 @@
 export interface Email {
-  id?: number;
+  id?: string;
   email: string;
-  userId: number;
+  userId: string;
   isVerified?: boolean;
   isPrimary?: boolean;
   createdAt?: Date;

--- a/src/interfaces/tables/events.ts
+++ b/src/interfaces/tables/events.ts
@@ -2,9 +2,9 @@ import { EventType, Webhooks } from "../enum";
 import { GeoLocation } from "../../helpers/location";
 
 export interface Event {
-  id?: number;
-  userId?: number;
-  organizationId?: number;
+  id?: string;
+  userId?: string;
+  organizationId?: string;
   type?: EventType | Webhooks;
   data?: string | object;
   ipAddress?: string;

--- a/src/interfaces/tables/memberships.ts
+++ b/src/interfaces/tables/memberships.ts
@@ -1,9 +1,9 @@
 import { MembershipRole } from "../enum";
 
 export interface Membership {
-  id?: number;
-  organizationId: number;
-  userId: number;
+  id?: string;
+  organizationId: string;
+  userId: string;
   role: MembershipRole;
   createdAt?: Date;
   updatedAt?: Date;

--- a/src/interfaces/tables/organization.ts
+++ b/src/interfaces/tables/organization.ts
@@ -17,21 +17,21 @@ export interface ApiKey extends IdRow {
   description?: string;
   jwtApiKey?: string;
   scopes?: string;
-  organizationId: number;
+  organizationId: string;
   ipRestrictions?: string;
   referrerRestrictions?: string;
   expiresAt?: Date;
 }
 
 export interface Domain extends IdRow {
-  organizationId: number;
+  organizationId: string;
   domain: string;
   verificationCode?: string;
   isVerified: boolean;
 }
 
 export interface Webhook extends IdRow {
-  organizationId: number;
+  organizationId: string;
   url: string;
   event: Webhooks;
   contentType: "application/json" | "application/x-www-form-urlencoded";

--- a/src/interfaces/tables/user.ts
+++ b/src/interfaces/tables/user.ts
@@ -26,15 +26,15 @@ export interface User extends IdRow {
 }
 
 export interface ApprovedLocation {
-  id?: number;
-  userId?: number;
+  id?: string;
+  userId?: string;
   subnet?: string;
   createdAt?: Date;
 }
 
 export interface BackupCode extends Row {
   code: number;
-  userId: number;
+  userId: string;
   used?: boolean;
 }
 
@@ -43,12 +43,12 @@ export interface AccessToken extends IdRow {
   description?: string;
   jwtAccessToken?: string;
   scopes?: string;
-  userId: number;
+  userId: string;
   expiresAt?: Date;
 }
 export interface AccessTokenResponse {
-  id: number;
-  userId: number;
+  id: string;
+  userId: string;
   scopes: string;
   jti: string;
   sub: Tokens;
@@ -56,7 +56,7 @@ export interface AccessTokenResponse {
 }
 
 export interface Session extends IdRow {
-  userId: number;
+  userId: string;
   jwtToken: string;
   ipAddress: string;
   userAgent: string;

--- a/src/interfaces/tables/user.ts
+++ b/src/interfaces/tables/user.ts
@@ -6,7 +6,7 @@ export interface User extends IdRow {
   name: string;
   username?: string;
   nickname?: string;
-  primaryEmail?: number;
+  primaryEmail?: string;
   password?: string;
   twoFactorEnabled?: boolean;
   twoFactorSecret?: string;

--- a/src/rest/admin.ts
+++ b/src/rest/admin.ts
@@ -9,7 +9,7 @@ import {
 import ms from "ms";
 
 export const getAllOrganizationForUser = async (
-  tokenUserId: number,
+  tokenUserId: string,
   query: KeyValue
 ) => {
   if (await can(tokenUserId, Authorizations.READ, "general"))
@@ -21,7 +21,7 @@ export const getAllOrganizationForUser = async (
 };
 
 export const getAllUsersForUser = async (
-  tokenUserId: number,
+  tokenUserId: string,
   query: KeyValue
 ) => {
   if (await can(tokenUserId, Authorizations.READ, "general"))
@@ -36,7 +36,7 @@ export const getAllUsersForUser = async (
  * Get an API key
  */
 export const getServerLogsForUser = async (
-  tokenUserId: number,
+  tokenUserId: string,
   query: KeyValue
 ) => {
   if (!(await can(tokenUserId, Authorizations.READ, "general")))

--- a/src/rest/admin.ts
+++ b/src/rest/admin.ts
@@ -7,6 +7,7 @@ import {
   elasticSearch
 } from "../helpers/elasticsearch";
 import ms from "ms";
+import { ELASTIC_LOGS_PREFIX } from "../config";
 
 export const getAllOrganizationForUser = async (
   tokenUserId: string,
@@ -44,7 +45,7 @@ export const getServerLogsForUser = async (
   const range: string = query.range || "7d";
   const from = query.from ? parseInt(query.from) : 0;
   const result = await elasticSearch.search({
-    index: `staart-logs-*`,
+    index: `${ELASTIC_LOGS_PREFIX}*`,
     from,
     body: {
       query: {

--- a/src/rest/auth.ts
+++ b/src/rest/auth.ts
@@ -98,7 +98,7 @@ export const register = async (
   user: User,
   locals?: Locals,
   email?: string,
-  organizationId?: number,
+  organizationId?: string,
   role?: MembershipRole,
   emailVerified?: boolean
 ) => {
@@ -168,7 +168,7 @@ export const sendPasswordReset = async (email: string, locals?: Locals) => {
   return;
 };
 
-export const sendNewPassword = async (userId: number, email: string) => {
+export const sendNewPassword = async (userId: string, email: string) => {
   const user = await getUser(userId);
   const userEmails = await getUserEmails(userId);
   if (!userEmails.filter(userEmail => userEmail.email === email).length)
@@ -211,8 +211,8 @@ export const updatePassword = async (
 };
 
 export const impersonate = async (
-  tokenUserId: number,
-  impersonateUserId: number,
+  tokenUserId: string,
+  impersonateUserId: string,
   locals: Locals
 ) => {
   if (

--- a/src/rest/email.ts
+++ b/src/rest/email.ts
@@ -16,8 +16,8 @@ import { addIsPrimaryToEmails } from "../helpers/mysql";
 import { trackEvent } from "../helpers/tracking";
 
 export const getAllEmailsForUser = async (
-  tokenUserId: number,
-  userId: number,
+  tokenUserId: string,
+  userId: string,
   query: KeyValue
 ) => {
   if (await can(tokenUserId, UserScopes.READ_USER_EMAILS, "user", userId)) {
@@ -33,9 +33,9 @@ export const getAllEmailsForUser = async (
 };
 
 export const getEmailForUser = async (
-  tokenUserId: number,
-  userId: number,
-  emailId: number
+  tokenUserId: string,
+  userId: string,
+  emailId: string
 ) => {
   if (await can(tokenUserId, UserScopes.READ_USER_EMAILS, "user", userId))
     return await getEmail(emailId);
@@ -43,9 +43,9 @@ export const getEmailForUser = async (
 };
 
 export const resendEmailVerificationForUser = async (
-  tokenUserId: number,
-  userId: number,
-  emailId: number
+  tokenUserId: string,
+  userId: string,
+  emailId: string
 ) => {
   if (
     await can(
@@ -60,8 +60,8 @@ export const resendEmailVerificationForUser = async (
 };
 
 export const addEmailToUserForUser = async (
-  tokenUserId: number,
-  userId: number,
+  tokenUserId: string,
+  userId: string,
   email: string,
   locals: Locals
 ) => {
@@ -77,9 +77,9 @@ export const addEmailToUserForUser = async (
 };
 
 export const deleteEmailFromUserForUser = async (
-  tokenUserId: number,
-  userId: number,
-  emailId: number,
+  tokenUserId: string,
+  userId: string,
+  emailId: string,
   locals: Locals
 ) => {
   if (!(await can(tokenUserId, UserScopes.DELETE_USER_EMAILS, "user", userId)))

--- a/src/rest/membership.ts
+++ b/src/rest/membership.ts
@@ -23,8 +23,8 @@ import { getOrganization, getDomainByDomainName } from "../crud/organization";
 import { trackEvent } from "../helpers/tracking";
 
 export const getMembershipDetailsForUser = async (
-  userId: number,
-  membershipId: number
+  userId: string,
+  membershipId: string
 ) => {
   if (await can(userId, Authorizations.READ, "membership", membershipId))
     return await getMembershipDetailed(membershipId);
@@ -32,8 +32,8 @@ export const getMembershipDetailsForUser = async (
 };
 
 export const deleteMembershipForUser = async (
-  tokenUserId: number | ApiKeyResponse,
-  membershipId: number,
+  tokenUserId: string | ApiKeyResponse,
+  membershipId: string,
   locals: Locals
 ) => {
   const membership = await getMembership(membershipId);
@@ -64,8 +64,8 @@ export const deleteMembershipForUser = async (
 };
 
 export const updateMembershipForUser = async (
-  userId: number | ApiKeyResponse,
-  membershipId: number,
+  userId: string | ApiKeyResponse,
+  membershipId: string,
   data: KeyValue,
   locals: Locals
 ) => {

--- a/src/rest/organization.ts
+++ b/src/rest/organization.ts
@@ -641,7 +641,7 @@ export const inviteMemberToOrganization = async (
     }
     let newUser: User;
     let userExists = false;
-    let createdUserId = 0;
+    let createdUserId: string;
     try {
       newUser = await getUserByEmail(newMemberEmail);
       userExists = true;

--- a/src/rest/organization.ts
+++ b/src/rest/organization.ts
@@ -75,8 +75,8 @@ import { trackEvent } from "../helpers/tracking";
 import { mail } from "../helpers/mail";
 
 export const getOrganizationForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number
+  userId: string | ApiKeyResponse,
+  organizationId: string
 ) => {
   if (await can(userId, OrgScopes.READ_ORG, "organization", organizationId))
     return await getOrganization(organizationId);
@@ -84,7 +84,7 @@ export const getOrganizationForUser = async (
 };
 
 export const newOrganizationForUser = async (
-  userId: number,
+  userId: string,
   organization: Organization,
   locals: Locals
 ) => {
@@ -107,8 +107,8 @@ export const newOrganizationForUser = async (
 };
 
 export const updateOrganizationForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
   data: Organization,
   locals: Locals
 ) => {
@@ -122,8 +122,8 @@ export const updateOrganizationForUser = async (
 };
 
 export const deleteOrganizationForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
   locals: Locals
 ) => {
   if (await can(userId, OrgScopes.DELETE_ORG, "organization", organizationId)) {
@@ -140,8 +140,8 @@ export const deleteOrganizationForUser = async (
 };
 
 export const getOrganizationBillingForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number
+  userId: string | ApiKeyResponse,
+  organizationId: string
 ) => {
   if (
     await can(
@@ -160,8 +160,8 @@ export const getOrganizationBillingForUser = async (
 };
 
 export const updateOrganizationBillingForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
   data: any,
   locals: Locals
 ) => {
@@ -191,8 +191,8 @@ export const updateOrganizationBillingForUser = async (
 };
 
 export const getOrganizationInvoicesForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
   params: KeyValue
 ) => {
   if (
@@ -212,8 +212,8 @@ export const getOrganizationInvoicesForUser = async (
 };
 
 export const getOrganizationInvoiceForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
   invoiceId: string
 ) => {
   if (
@@ -233,8 +233,8 @@ export const getOrganizationInvoiceForUser = async (
 };
 
 export const getOrganizationSourcesForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
   params: KeyValue
 ) => {
   if (
@@ -254,8 +254,8 @@ export const getOrganizationSourcesForUser = async (
 };
 
 export const getOrganizationSourceForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
   sourceId: string
 ) => {
   if (
@@ -275,8 +275,8 @@ export const getOrganizationSourceForUser = async (
 };
 
 export const getOrganizationSubscriptionsForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
   params: KeyValue
 ) => {
   if (
@@ -299,8 +299,8 @@ export const getOrganizationSubscriptionsForUser = async (
 };
 
 export const getOrganizationSubscriptionForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
   subscriptionId: string
 ) => {
   if (
@@ -323,8 +323,8 @@ export const getOrganizationSubscriptionForUser = async (
 };
 
 export const updateOrganizationSubscriptionForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
   subscriptionId: string,
   data: KeyValue,
   locals?: Locals
@@ -357,8 +357,8 @@ export const updateOrganizationSubscriptionForUser = async (
 };
 
 export const createOrganizationSubscriptionForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
   params: { plan: string; [index: string]: any },
   locals?: Locals
 ) => {
@@ -389,8 +389,8 @@ export const createOrganizationSubscriptionForUser = async (
 };
 
 export const getOrganizationPricingPlansForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number
+  userId: string | ApiKeyResponse,
+  organizationId: string
 ) => {
   if (
     await can(userId, OrgScopes.READ_ORG_PLANS, "organization", organizationId)
@@ -400,8 +400,8 @@ export const getOrganizationPricingPlansForUser = async (
 };
 
 export const deleteOrganizationSourceForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
   sourceId: string,
   locals?: Locals
 ) => {
@@ -432,8 +432,8 @@ export const deleteOrganizationSourceForUser = async (
 };
 
 export const updateOrganizationSourceForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
   sourceId: string,
   data: any,
   locals?: Locals
@@ -466,8 +466,8 @@ export const updateOrganizationSourceForUser = async (
 };
 
 export const createOrganizationSourceForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
   card: any,
   locals?: Locals
 ) => {
@@ -498,8 +498,8 @@ export const createOrganizationSourceForUser = async (
 };
 
 export const getAllOrganizationDataForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number
+  userId: string | ApiKeyResponse,
+  organizationId: string
 ) => {
   if (
     await can(
@@ -537,8 +537,8 @@ export const getAllOrganizationDataForUser = async (
 };
 
 export const getOrganizationMembershipsForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
   query?: KeyValue
 ) => {
   if (
@@ -554,9 +554,9 @@ export const getOrganizationMembershipsForUser = async (
 };
 
 export const getOrganizationMembershipForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
-  membershipId: number
+  userId: string | ApiKeyResponse,
+  organizationId: string,
+  membershipId: string
 ) => {
   if (
     await can(
@@ -574,9 +574,9 @@ export const getOrganizationMembershipForUser = async (
 };
 
 export const updateOrganizationMembershipForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
-  membershipId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
+  membershipId: string,
   data: KeyValue
 ) => {
   if (
@@ -596,9 +596,9 @@ export const updateOrganizationMembershipForUser = async (
 };
 
 export const deleteOrganizationMembershipForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
-  membershipId: number
+  userId: string | ApiKeyResponse,
+  organizationId: string,
+  membershipId: string
 ) => {
   if (
     await can(
@@ -613,8 +613,8 @@ export const deleteOrganizationMembershipForUser = async (
 };
 
 export const inviteMemberToOrganization = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
   newMemberName: string,
   newMemberEmail: string,
   role: MembershipRole,
@@ -687,8 +687,8 @@ export const inviteMemberToOrganization = async (
 };
 
 export const getOrganizationApiKeysForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
   query: KeyValue
 ) => {
   if (
@@ -704,9 +704,9 @@ export const getOrganizationApiKeysForUser = async (
 };
 
 export const getOrganizationApiKeyForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
-  apiKeyId: number
+  userId: string | ApiKeyResponse,
+  organizationId: string,
+  apiKeyId: string
 ) => {
   if (
     await can(
@@ -721,9 +721,9 @@ export const getOrganizationApiKeyForUser = async (
 };
 
 export const getOrganizationApiKeyLogsForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
-  apiKeyId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
+  apiKeyId: string,
   query: KeyValue
 ) => {
   if (
@@ -739,9 +739,9 @@ export const getOrganizationApiKeyLogsForUser = async (
 };
 
 export const updateApiKeyForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
-  apiKeyId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
+  apiKeyId: string,
   data: KeyValue,
   locals: Locals
 ) => {
@@ -762,8 +762,8 @@ export const updateApiKeyForUser = async (
 };
 
 export const createApiKeyForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
   apiKey: KeyValue,
   locals: Locals
 ) => {
@@ -784,9 +784,9 @@ export const createApiKeyForUser = async (
 };
 
 export const deleteApiKeyForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
-  apiKeyId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
+  apiKeyId: string,
   locals: Locals
 ) => {
   if (
@@ -806,8 +806,8 @@ export const deleteApiKeyForUser = async (
 };
 
 export const getOrganizationDomainsForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
   query: KeyValue
 ) => {
   if (
@@ -823,9 +823,9 @@ export const getOrganizationDomainsForUser = async (
 };
 
 export const getOrganizationDomainForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
-  domainId: number
+  userId: string | ApiKeyResponse,
+  organizationId: string,
+  domainId: string
 ) => {
   if (
     await can(
@@ -840,9 +840,9 @@ export const getOrganizationDomainForUser = async (
 };
 
 export const updateDomainForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
-  domainId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
+  domainId: string,
   data: KeyValue,
   locals: Locals
 ) => {
@@ -863,8 +863,8 @@ export const updateDomainForUser = async (
 };
 
 export const createDomainForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
   domain: KeyValue,
   locals: Locals
 ) => {
@@ -891,9 +891,9 @@ export const createDomainForUser = async (
 };
 
 export const deleteDomainForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
-  domainId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
+  domainId: string,
   locals: Locals
 ) => {
   if (
@@ -913,9 +913,9 @@ export const deleteDomainForUser = async (
 };
 
 export const verifyDomainForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
-  domainId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
+  domainId: string,
   method: "dns" | "file",
   locals: Locals
 ) => {
@@ -966,8 +966,8 @@ export const verifyDomainForUser = async (
 };
 
 export const getOrganizationWebhooksForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
   query: KeyValue
 ) => {
   if (
@@ -983,9 +983,9 @@ export const getOrganizationWebhooksForUser = async (
 };
 
 export const getOrganizationWebhookForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
-  webhookId: number
+  userId: string | ApiKeyResponse,
+  organizationId: string,
+  webhookId: string
 ) => {
   if (
     await can(
@@ -1000,9 +1000,9 @@ export const getOrganizationWebhookForUser = async (
 };
 
 export const updateWebhookForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
-  webhookId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
+  webhookId: string,
   data: KeyValue,
   locals: Locals
 ) => {
@@ -1023,8 +1023,8 @@ export const updateWebhookForUser = async (
 };
 
 export const createWebhookForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
   webhook: KeyValue,
   locals: Locals
 ) => {
@@ -1048,9 +1048,9 @@ export const createWebhookForUser = async (
 };
 
 export const deleteWebhookForUser = async (
-  userId: number | ApiKeyResponse,
-  organizationId: number,
-  webhookId: number,
+  userId: string | ApiKeyResponse,
+  organizationId: string,
+  webhookId: string,
   locals: Locals
 ) => {
   if (

--- a/src/rest/user.ts
+++ b/src/rest/user.ts
@@ -34,15 +34,15 @@ import { getPaginatedData } from "../crud/data";
 import { addLocationToEvents } from "../helpers/location";
 import { trackEvent } from "../helpers/tracking";
 
-export const getUserFromId = async (userId: number, tokenUserId: number) => {
+export const getUserFromId = async (userId: string, tokenUserId: string) => {
   if (await can(tokenUserId, UserScopes.READ_USER, "user", userId))
     return getUser(userId);
   throw new Error(ErrorCode.INSUFFICIENT_PERMISSION);
 };
 
 export const updateUserForUser = async (
-  tokenUserId: number,
-  updateUserId: number,
+  tokenUserId: string,
+  updateUserId: string,
   data: User,
   locals: Locals
 ) => {
@@ -63,8 +63,8 @@ export const updateUserForUser = async (
 };
 
 export const updatePasswordForUser = async (
-  tokenUserId: number,
-  updateUserId: number,
+  tokenUserId: string,
+  updateUserId: string,
   oldPassword: string,
   newPassword: string,
   locals: Locals
@@ -91,8 +91,8 @@ export const updatePasswordForUser = async (
 };
 
 export const deleteUserForUser = async (
-  tokenUserId: number,
-  updateUserId: number,
+  tokenUserId: string,
+  updateUserId: string,
   locals: Locals
 ) => {
   if (await can(tokenUserId, UserScopes.DELETE_USER, "user", updateUserId)) {
@@ -114,8 +114,8 @@ export const deleteUserForUser = async (
 };
 
 export const getRecentEventsForUser = async (
-  tokenUserId: number,
-  dataUserId: number,
+  tokenUserId: string,
+  dataUserId: string,
   query: KeyValue
 ) => {
   if (await can(tokenUserId, UserScopes.READ_USER, "user", dataUserId)) {
@@ -131,8 +131,8 @@ export const getRecentEventsForUser = async (
 };
 
 export const getMembershipsForUser = async (
-  tokenUserId: number,
-  dataUserId: number,
+  tokenUserId: string,
+  dataUserId: string,
   query: KeyValue
 ) => {
   if (
@@ -150,8 +150,8 @@ export const getMembershipsForUser = async (
 };
 
 export const getAllDataForUser = async (
-  tokenUserId: number,
-  userId: number
+  tokenUserId: string,
+  userId: string
 ) => {
   // Rethink this permission
   if (!(await can(tokenUserId, UserScopes.READ_USER, "user", userId)))
@@ -163,7 +163,7 @@ export const getAllDataForUser = async (
   return { user, memberships, emails, approvedLocations };
 };
 
-export const enable2FAForUser = async (tokenUserId: number, userId: number) => {
+export const enable2FAForUser = async (tokenUserId: string, userId: string) => {
   if (!(await can(tokenUserId, UserScopes.ENABLE_USER_2FA, "user", userId)))
     throw new Error(ErrorCode.INSUFFICIENT_PERMISSION);
   const secret = authenticator.generateSecret();
@@ -174,8 +174,8 @@ export const enable2FAForUser = async (tokenUserId: number, userId: number) => {
 };
 
 export const verify2FAForUser = async (
-  tokenUserId: number,
-  userId: number,
+  tokenUserId: string,
+  userId: string,
   verificationCode: number
 ) => {
   if (!(await can(tokenUserId, UserScopes.ENABLE_USER_2FA, "user", userId)))
@@ -189,8 +189,8 @@ export const verify2FAForUser = async (
 };
 
 export const disable2FAForUser = async (
-  tokenUserId: number,
-  userId: number
+  tokenUserId: string,
+  userId: string
 ) => {
   if (!(await can(tokenUserId, UserScopes.DISABLE_USER_2FA, "user", userId)))
     throw new Error(ErrorCode.INSUFFICIENT_PERMISSION);
@@ -199,8 +199,8 @@ export const disable2FAForUser = async (
 };
 
 export const getBackupCodesForUser = async (
-  tokenUserId: number,
-  userId: number
+  tokenUserId: string,
+  userId: string
 ) => {
   if (
     !(await can(tokenUserId, UserScopes.READ_USER_BACKUP_CODES, "user", userId))
@@ -210,8 +210,8 @@ export const getBackupCodesForUser = async (
 };
 
 export const regenerateBackupCodesForUser = async (
-  tokenUserId: number,
-  userId: number
+  tokenUserId: string,
+  userId: string
 ) => {
   if (
     !(await can(
@@ -228,8 +228,8 @@ export const regenerateBackupCodesForUser = async (
 };
 
 export const getUserAccessTokensForUser = async (
-  tokenUserId: number,
-  userId: number,
+  tokenUserId: string,
+  userId: string,
   query: KeyValue
 ) => {
   if (
@@ -240,9 +240,9 @@ export const getUserAccessTokensForUser = async (
 };
 
 export const getUserAccessTokenForUser = async (
-  tokenUserId: number,
-  userId: number,
-  accessTokenId: number
+  tokenUserId: string,
+  userId: string,
+  accessTokenId: string
 ) => {
   if (
     await can(tokenUserId, UserScopes.READ_USER_ACCESS_TOKENS, "user", userId)
@@ -252,9 +252,9 @@ export const getUserAccessTokenForUser = async (
 };
 
 export const updateAccessTokenForUser = async (
-  tokenUserId: number,
-  userId: number,
-  accessTokenId: number,
+  tokenUserId: string,
+  userId: string,
+  accessTokenId: string,
   data: KeyValue,
   locals: Locals
 ) => {
@@ -268,8 +268,8 @@ export const updateAccessTokenForUser = async (
 };
 
 export const createAccessTokenForUser = async (
-  tokenUserId: number,
-  userId: number,
+  tokenUserId: string,
+  userId: string,
   accessToken: KeyValue,
   locals: Locals
 ) => {
@@ -283,9 +283,9 @@ export const createAccessTokenForUser = async (
 };
 
 export const deleteAccessTokenForUser = async (
-  tokenUserId: number,
-  userId: number,
-  accessTokenId: number,
+  tokenUserId: string,
+  userId: string,
+  accessTokenId: string,
   locals: Locals
 ) => {
   if (
@@ -298,8 +298,8 @@ export const deleteAccessTokenForUser = async (
 };
 
 export const getUserSessionsForUser = async (
-  tokenUserId: number,
-  userId: number,
+  tokenUserId: string,
+  userId: string,
   query: KeyValue
 ) => {
   if (await can(tokenUserId, UserScopes.READ_USER_SESSION, "user", userId))
@@ -308,9 +308,9 @@ export const getUserSessionsForUser = async (
 };
 
 export const getUserSessionForUser = async (
-  tokenUserId: number,
-  userId: number,
-  sessionId: number
+  tokenUserId: string,
+  userId: string,
+  sessionId: string
 ) => {
   if (await can(tokenUserId, UserScopes.READ_USER_SESSION, "user", userId))
     return await getSession(userId, sessionId);
@@ -318,9 +318,9 @@ export const getUserSessionForUser = async (
 };
 
 export const deleteSessionForUser = async (
-  tokenUserId: number,
-  userId: number,
-  sessionId: number,
+  tokenUserId: string,
+  userId: string,
+  sessionId: string,
   locals: Locals
 ) => {
   if (await can(tokenUserId, UserScopes.DELETE_USER_SESSION, "user", userId)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3499,6 +3499,11 @@ has@^1.0.1, has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hashids@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/hashids/-/hashids-2.0.0.tgz#8a3ad77598233e399594b73ad5fdb3c2c880528e"
+  integrity sha512-URg7dQlk6wQS9WqhQwKBC0cT/G0JMaEcwlHTvtRNB45JcIrr6mxY7dXiCUJwESf+tXnyaFdz7C8ETDYrQsyY1A==
+
 helmet-crossdomain@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/helmet-crossdomain/-/helmet-crossdomain-0.4.0.tgz#5f1fe5a836d0325f1da0a78eaa5fd8429078894e"


### PR DESCRIPTION
This PR adds support for using a hashed* ID instead of MySQL's default integer IDs. Instead of exposing a row's actual ID, we convert to and from `hashids`.

For example, hitting the `/v1/users/anand/emails` endpoint will give you:

```json
{
  "data": [
    {
      "id": "d0e8a7c-kgne2y5p4v",
      "email": "anandchowdhary@gmail.com",
      "userId": "d0e8a7c-kgne2y5p4v",
      "isVerified": true,
      "createdAt": "2019-07-17T10:34:57.000Z",
      "updatedAt": "2019-07-17T11:02:17.000Z",
      "isPrimary": true
    }
  ],
  "hasMore": false,
  "next": false
}
```

As you'll notice, the ID of the email is `d0e8a7c-kgne2y5p4v` instead of a number like `5`.

\* Not actually hashed